### PR TITLE
[Feat/#21] Spacing & Divider 컴포넌트 구현

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,7 @@
     "lineWidth": 120,
     "attributePosition": "auto"
   },
-  "organizeImports": { "enabled": true },
+  "organizeImports": { "enabled": false },
   "linter": {
     "enabled": true,
     "rules": {
@@ -34,6 +34,11 @@
         "noUnusedImports": {
           "level": "warn",
           "fix": "safe"
+        }
+      },
+      "style": {
+        "useImportType": {
+          "level": "off"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5.62.11",
     "@vanilla-extract/css": "^1.17.0",
+    "@vanilla-extract/dynamic": "^2.1.2",
+    "@vanilla-extract/recipes": "^0.5.5",
     "axios": "^1.7.9",
     "openapi-typescript": "^7.5.2",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.0
+      '@vanilla-extract/dynamic':
+        specifier: ^2.1.2
+        version: 2.1.2
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.5
+        version: 0.5.5(@vanilla-extract/css@1.17.0)
       axios:
         specifier: ^1.7.9
         version: 1.7.9
@@ -965,11 +971,19 @@ packages:
   '@vanilla-extract/css@1.17.0':
     resolution: {integrity: sha512-W6FqVFDD+C71ZlKsuj0MxOXSvHb1tvQ9h/+79aYfi097wLsALrnnBzd0by8C///iurrpQ3S+SH74lXd7Lr9MvA==}
 
+  '@vanilla-extract/dynamic@2.1.2':
+    resolution: {integrity: sha512-9BGMciD8rO1hdSPIAh1ntsG4LPD3IYKhywR7VOmmz9OO4Lx1hlwkSg3E6X07ujFx7YuBfx0GDQnApG9ESHvB2A==}
+
   '@vanilla-extract/integration@7.1.12':
     resolution: {integrity: sha512-71HFjnfL7qXM3hqyk7z9c8zrudfO9Sut6IhSmH8IKwmLk/tIMFIL86L6nYpItfUFUa/mrER6YUQPp/SfwjRvkw==}
 
   '@vanilla-extract/private@1.0.6':
     resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
+
+  '@vanilla-extract/recipes@0.5.5':
+    resolution: {integrity: sha512-VadU7+IFUwLNLMgks29AHav/K5h7DOEfTU91RItn5vwdPfzduodNg317YbgWCcpm7FSXkuR3B3X8ZOi95UOozA==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
 
   '@vanilla-extract/vite-plugin@4.0.19':
     resolution: {integrity: sha512-NtE/sAIesCAu+6JHlanLgmfDJn/cqG8dfElfh5n1PvG2LTSMVMQhVbDefxcVhGjw1lt5QbG+u3dpZMY7KPwJhw==}
@@ -2336,6 +2350,10 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
+  '@vanilla-extract/dynamic@2.1.2':
+    dependencies:
+      '@vanilla-extract/private': 1.0.6
+
   '@vanilla-extract/integration@7.1.12(@types/node@22.10.5)':
     dependencies:
       '@babel/core': 7.26.0
@@ -2363,6 +2381,10 @@ snapshots:
       - terser
 
   '@vanilla-extract/private@1.0.6': {}
+
+  '@vanilla-extract/recipes@0.5.5(@vanilla-extract/css@1.17.0)':
+    dependencies:
+      '@vanilla-extract/css': 1.17.0
 
   '@vanilla-extract/vite-plugin@4.0.19(@types/node@22.10.5)(vite@6.0.7(@types/node@22.10.5))':
     dependencies:

--- a/src/common/component/Divider/Divider.css.ts
+++ b/src/common/component/Divider/Divider.css.ts
@@ -1,0 +1,24 @@
+import { semanticColor } from "@style/styles.css";
+import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
+
+export const divider = recipe({
+  base: {
+    width: "100%",
+    backgroundColor: semanticColor.line.normal,
+  },
+
+  variants: {
+    size: {
+      large: { height: "1.6rem" },
+      small: { height: "0.1rem" },
+    },
+  },
+});
+
+export type DividerVariants = RecipeVariants<typeof divider>;
+//위는 아래와 동일한 타입 생성
+/*
+export type DividerVariants = {
+    size?: 'large' | 'small' 
+}
+*/

--- a/src/common/component/Divider/Divider.tsx
+++ b/src/common/component/Divider/Divider.tsx
@@ -1,0 +1,9 @@
+import { divider, DividerVariants } from "./Divider.css";
+
+type DividerPropTypes = Exclude<DividerVariants, undefined>;
+
+const Divider = ({ size = "large" }: DividerPropTypes) => {
+  return <div className={divider({ size: size })} />;
+};
+
+export default Divider;

--- a/src/common/component/Spacing/Spacing.css.ts
+++ b/src/common/component/Spacing/Spacing.css.ts
@@ -1,0 +1,8 @@
+import { createVar, style } from "@vanilla-extract/css";
+
+//동적 스타일링 (style 관련된 코드는 반드시 .css.ts에 작성하는게 rule
+export const marginBottomVar = createVar();
+export const container = style({
+  marginBottom: marginBottomVar,
+  backgroundColor: "black",
+});

--- a/src/common/component/Spacing/Spacing.tsx
+++ b/src/common/component/Spacing/Spacing.tsx
@@ -1,0 +1,19 @@
+import { assignInlineVars } from "@vanilla-extract/dynamic";
+import { container, marginBottomVar } from "./Spacing.css";
+
+interface SpacingPropTypes {
+  marginBottom?: string;
+}
+
+const Spacing = ({ marginBottom = "1" }: SpacingPropTypes) => {
+  return (
+    <div
+      className={container}
+      style={assignInlineVars({
+        [marginBottomVar]: `${marginBottom}rem`, //변수값 조정은 여기서 !
+      })}
+    />
+  );
+};
+
+export default Spacing;

--- a/src/page/main/index/Main.tsx
+++ b/src/page/main/index/Main.tsx
@@ -1,3 +1,4 @@
+import Divider from "@common/component/Divider/Divider";
 import Spacing from "@common/component/Spacing/Spacing";
 
 /*
@@ -8,6 +9,9 @@ const Main = () => {
     <div>
       <span>main</span>
       <Spacing marginBottom="10" />
+      <Divider size="small" />
+      <Spacing marginBottom="10" />
+      <Divider />
     </div>
   );
 };

--- a/src/page/main/index/Main.tsx
+++ b/src/page/main/index/Main.tsx
@@ -1,8 +1,15 @@
+import Spacing from "@common/component/Spacing/Spacing";
+
 /*
 localhost:5173/main
 */
 const Main = () => {
-  return <div>Main</div>;
+  return (
+    <div>
+      <span>main</span>
+      <Spacing marginBottom="10" />
+    </div>
+  );
 };
 
 export default Main;


### PR DESCRIPTION
## 🔥 Related Issues

- close #21 

## ✅ 작업 리스트

- [x] Spacing 구현
- [x] Divider 구현
- [x] biome이 type을 제대로 import 해오지 못하고, type type type 과 같은 문제를 일으켜 비활성화 했습니다.

## 🔧 작업 내용

## 📣 리뷰어에게 어떠신가요?
- 바닐라 익스트랙트에서 동적 변수를 통한 스타일링을 위해서는 createVar() 뿐만 아니라 assignInlineVars 를 사용해야하기 때문에 @vanilla-extract/dynamic 를 추가로 설치했습니다. 
- 바닐라 익스트랙트의 스타일링을 위해서는 반드시 .css.ts 파일로 분리하여 작성해야 합니다. (rule)
- 동적 변수 스타일링이 아닌 다양한 variants를 적용하기 위해서는 recipe()을 사용했습니다. 이를 위해 @vanilla-extract/recipe를 설치했습니다.
- 간단히 말해, recipe는 정해진 스타일 변형을 위한 규격화된 방식, assignInlineVar는 컴포넌트가 렌더링될 때 동적으로 값이 할당하는 방식이라고 생각하시면 됩니다.

사용방법은 간단합니다.
<img width="540" alt="image" src="https://github.com/user-attachments/assets/9b671f5e-2f58-4008-9808-c20bf2d1c808" />

위, 아래로 간격을 주고 싶을 때 <Spacing/> 을 사용하는데, marginBottom이라는 prop에 rem 단위의 값을 숫자(형식은 문자열)만 입력하면 됩니다. 위의 예시는 10rem의 간격을 주었습니다. (prop은 optional, default 값은 1(rem))

<Divider/>는 size 라는 prop에 "large" | "small" 중 하나를 주면 됩니다. (prop은 optional, default 값은 "large")

## 📸 스크린샷 / GIF / Link
사용한 모습 (예시, main에 있는건 언제든 지워도 좋습니다.)
<img width="809" alt="image" src="https://github.com/user-attachments/assets/cece27a5-e998-483a-8d7c-96915f6de1d6" />

