### PR TITLE
[Feat/#43] path 파일로 경로 지정

### DIFF
--- a/src/route/Community.tsx
+++ b/src/route/Community.tsx
@@ -2,12 +2,13 @@ import Community from "@page/community/index/Community";
 import Post from "@page/community/post/Post";
 import Search from "@page/community/search/Search";
 import Write from "@page/community/write/Write";
+import { PATH } from "@route/path.ts";
 
 const COMMUNITY_ROUTES = [
-    { path: "/community", element: <Community /> },
-    {path: "community/post", element: <Post/>},
-    {path: "community/search", element: <Search/>},
-    {path: "community/write", element: <Write/>},
-  ];
-  
-  export default COMMUNITY_ROUTES;
+  { path: PATH.COMMUNITY.ROOT, element: <Community /> },
+  { path: PATH.COMMUNITY.POST, element: <Post /> },
+  { path: PATH.COMMUNITY.SEARCH, element: <Search /> },
+  { path: PATH.COMMUNITY.WRITE, element: <Write /> },
+];
+
+export default COMMUNITY_ROUTES;

--- a/src/route/MainRoutes.tsx
+++ b/src/route/MainRoutes.tsx
@@ -1,7 +1,6 @@
 import Main from "@page/main/index/Main";
+import { PATH } from "@route/path.ts";
 
-const MAIN_ROUTES = [
-    { path: "/main", element: <Main /> },
-  ];
-  
+const MAIN_ROUTES = [{ path: PATH.MAIN, element: <Main /> }];
+
 export default MAIN_ROUTES;

--- a/src/route/MyPageRoutes.tsx
+++ b/src/route/MyPageRoutes.tsx
@@ -1,9 +1,10 @@
 import Mypage from "@page/mypage/index/Mypage";
 import Modify from "@page/mypage/modify/Modify";
+import { PATH } from "@route/path.ts";
 
-const MYPAGE_ROUTES= [
-    { path: "/mypage", element: <Mypage/> },
-    { path: "/mypage/modify", element: <Modify/> },
-  ];
-  
-  export default MYPAGE_ROUTES;
+const MYPAGE_ROUTES = [
+  { path: PATH.MYPAGE.ROOT, element: <Mypage /> },
+  { path: PATH.MYPAGE.MODIFY, element: <Modify /> },
+];
+
+export default MYPAGE_ROUTES;

--- a/src/route/OnboardingRoutes.tsx
+++ b/src/route/OnboardingRoutes.tsx
@@ -1,9 +1,10 @@
 import Complete from "@page/onboarding/complete/Complete";
 import Onboarding from "@page/onboarding/index/Onboarding";
+import { PATH } from "@route/path.ts";
 
 const ONBOARGING_ROUTES = [
-    { path: "/onboarding", element: <Onboarding /> },
-    { path: "/onboarding/complete", element: <Complete/> },
-  ];
-  
-  export default ONBOARGING_ROUTES;
+  { path: PATH.ONBOARDING.ROOT, element: <Onboarding /> },
+  { path: PATH.ONBOARDING.COMPLETE, element: <Complete /> },
+];
+
+export default ONBOARGING_ROUTES;

--- a/src/route/path.ts
+++ b/src/route/path.ts
@@ -1,0 +1,21 @@
+export const PATH = {
+  ONBOARDING: {
+    ROOT: "/onboarding",
+    COMPLETE: "/onboarding/complete",
+  },
+  MAIN: "/main",
+  COMMUNITY: {
+    ROOT: "/community",
+    POST: "/community/post",
+    SEARCH: "/community/search",
+    WRITE: "/community/write",
+  },
+  MYPAGE: {
+    ROOT: "/mypage",
+    MODIFY: "/mypage/modify",
+  },
+  SEARCH: {
+    ROOT: "/search",
+    DONE: "/search/done",
+  },
+};


### PR DESCRIPTION
## 🔥 Related Issues

- close #43 

## ✅ 작업 리스트

- [ ] path.ts 만들어서 모든 경로 지정
- [ ] route 파일에서도 경로 변수로 조정하도록 수정


## 🔧 작업 내용

path.ts 를 다음과 같이 만들었습니다. 
```typescript
export const PATH = {
  ONBOARDING: {
    ROOT: "/onboarding",
    COMPLETE: "/onboarding/complete",
  },
  MAIN: "/main",
  COMMUNITY: {
    ROOT: "/community",
    POST: "/community/post",
    SEARCH: "/community/search",
    WRITE: "/community/write",
  },
  MYPAGE: {
    ROOT: "/mypage",
    MODIFY: "/mypage/modify",
  },
  SEARCH: {
    ROOT: "/search",
    DONE: "/search/done",
  },
};
```
이렇게 만든 이유는, 제가 navigate 함수로 페이지를 변경할 때 일일이 직접 타이핑 하다가 이거 아닌 것 같아 수정 PR 올렸습니다.
다음과 같이 PATH 를 만들어서 navigate 를 하게 되면,

`navigate(PATH.SEARCH) 
`
-> 이렇게 구현이 가능한데, 이렇게 해야 추후 수정보완하기 편할 것 같아 해당 방법 적용하고 싶은데 혹시 괜찮을까요?

이거 불편하다 아닌 것 같다 하면 PR 제거하려 합니다! 편하게 의견 주세용

## 📣 리뷰어에게 어떠신가요?

## 📸 스크린샷 / GIF / Link
