### PR TITLE
[Refactor/#90] SimpleBottomSheet 리팩토링

### DIFF
--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
@@ -1,13 +1,29 @@
 import { style } from "@vanilla-extract/css";
 import { font, semanticColor } from "@style/styles.css";
 
+export const overlay = style({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  zIndex: "99",
+
+  width: "100%",
+  height: "100vh",
+  backgroundColor: "rgba(34, 34, 34, 0.2)",
+});
+
 export const bottomSheetContainer = style({
+  position: "absolute",
+  bottom: "0",
+
   display: "flex",
   width: "37.5rem",
   flexDirection: "column",
   justifyContent: "center",
   alignItems: "center",
   borderRadius: "20px 20px 0px 0px",
+
+  backgroundColor: "white",
 });
 
 export const bottomSheetHeader = style({

--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
@@ -1,5 +1,5 @@
 import { style } from "@vanilla-extract/css";
-import { font, semanticColor } from "@style/styles.css";
+import { color, font, semanticColor } from "@style/styles.css";
 
 export const overlay = style({
   position: "absolute",
@@ -45,12 +45,27 @@ export const contentContainer = style({
   gap: "2.4rem",
 });
 
+export const contentWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "1.2rem",
+});
+
 export const content = style([
   font.heading03,
   {
     alignSelf: "stretch",
     color: semanticColor.text.normal,
     letterSpacing: "-0.16px",
+  },
+]);
+
+export const subContent = style([
+  font.label01,
+  {
+    alignSelf: "stretch",
+    color: color.gray.gray500,
   },
 ]);
 

--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
@@ -10,16 +10,18 @@ interface BottomSheetProps {
 
 const SimpleBottomSheet = ({ leftClick, rightClick }: BottomSheetProps) => {
   return (
-    <div className={styles.bottomSheetContainer}>
-      <div className={styles.bottomSheetHeader}>
-        <IcBottomSheetLine />
-      </div>
-      <div className={styles.contentContainer}>
-        <p className={styles.content}>댓글을 정말 삭제할까요?</p>
-        <div className={styles.buttonContainer}>
-          <Button label="취소" size="large" variant="solidNeutral" disabled={false} onClick={leftClick} />
+    <div className={styles.overlay}>
+      <div className={styles.bottomSheetContainer}>
+        <div className={styles.bottomSheetHeader}>
+          <IcBottomSheetLine width={80} />
+        </div>
+        <div className={styles.contentContainer}>
+          <p className={styles.content}>댓글을 정말 삭제할까요?</p>
+          <div className={styles.buttonContainer}>
+            <Button label="취소" size="large" variant="solidNeutral" disabled={false} onClick={leftClick} />
 
-          <Button label="삭제할게요" size="large" variant="solidPrimary" disabled={false} onClick={rightClick} />
+            <Button label="삭제할게요" size="large" variant="solidPrimary" disabled={false} onClick={rightClick} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
@@ -4,23 +4,53 @@ import { Button } from "../Button";
 import React from "react";
 
 interface BottomSheetProps {
-  leftClick?: React.MouseEventHandler<HTMLButtonElement>;
-  rightClick?: React.MouseEventHandler<HTMLButtonElement>;
+  isOpen: boolean;
+  handleClose: () => void;
+  content: string;
+  subContent?: string;
+  leftText: string;
+  rightText: string;
+  leftOnClick: React.MouseEventHandler<HTMLButtonElement>;
+  rightOnClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const SimpleBottomSheet = ({ leftClick, rightClick }: BottomSheetProps) => {
-  return (
-    <div className={styles.overlay}>
-      <div className={styles.bottomSheetContainer}>
-        <div className={styles.bottomSheetHeader}>
-          <IcBottomSheetLine width={80} />
-        </div>
-        <div className={styles.contentContainer}>
-          <p className={styles.content}>댓글을 정말 삭제할까요?</p>
-          <div className={styles.buttonContainer}>
-            <Button label="취소" size="large" variant="solidNeutral" disabled={false} onClick={leftClick} />
+const SimpleBottomSheet = ({
+  isOpen,
+  handleClose,
+  content,
+  subContent = undefined,
+  leftText,
+  rightText,
+  leftOnClick,
+  rightOnClick,
+}: BottomSheetProps) => {
+  if (!isOpen) return;
 
-            <Button label="삭제할게요" size="large" variant="solidPrimary" disabled={false} onClick={rightClick} />
+  const handleBottomSheetClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation(); // 이벤트 전파 차단
+  };
+
+  return (
+    <div className={styles.overlay} onClick={handleClose}>
+      <div className={styles.bottomSheetContainer} onClick={handleBottomSheetClick}>
+        <div className={styles.bottomSheetHeader}>
+          <IcBottomSheetLine width={80} onClick={handleClose} />
+        </div>
+
+        <div className={styles.contentContainer}>
+          <div className={styles.contentWrapper}>
+            <p className={styles.content}>{content}</p>
+            {subContent && <p className={styles.subContent}>{subContent}</p>}
+          </div>
+          <div className={styles.buttonContainer}>
+            <Button label={`${leftText}`} size="large" variant="solidNeutral" disabled={false} onClick={leftOnClick} />
+            <Button
+              label={`${rightText}`}
+              size="large"
+              variant="solidPrimary"
+              disabled={false}
+              onClick={rightOnClick}
+            />
           </div>
         </div>
       </div>

--- a/src/page/test/Test.tsx
+++ b/src/page/test/Test.tsx
@@ -1,9 +1,22 @@
 import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet";
+import useSimpleBottomSheet from "@shared/hook/useSimpleBottomSheet";
 
 const Test = () => {
+  const { isOpen, openBottomSheet, closeBottomSheet } = useSimpleBottomSheet();
+  console.log(isOpen);
   return (
     <div>
-      <SimpleBottomSheet />
+      <button onClick={openBottomSheet}>시작</button>
+      <SimpleBottomSheet
+        isOpen={isOpen}
+        handleClose={closeBottomSheet}
+        content="로그아웃 하시겠어요?"
+        subContent="언제든 다시 오시면 기다리고 있을게요!"
+        leftText="취소"
+        rightText="로그아웃"
+        leftOnClick={() => alert("hi")}
+        rightOnClick={() => alert("hi")}
+      />
     </div>
   );
 };

--- a/src/page/test/Test.tsx
+++ b/src/page/test/Test.tsx
@@ -1,0 +1,11 @@
+import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet";
+
+const Test = () => {
+  return (
+    <div>
+      <SimpleBottomSheet />
+    </div>
+  );
+};
+
+export default Test;

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -4,10 +4,12 @@ import MAIN_ROUTES from "./MainRoutes";
 import MYPAGE_ROUTES from "./MyPageRoutes";
 import ONBOARGING_ROUTES from "./OnboardingRoutes";
 import PROFILE_ROUTES from "./ProfileRoutes";
+import Test from "@page/test/Test";
 
 //children은 Outlet에서 사용하는 방식 (레이아웃 지정해야할 때)
 const router = createBrowserRouter([
   { path: "/", element: <>just home</> },
+  { path: "/test", element: <Test /> },
   ...ONBOARGING_ROUTES,
   ...MAIN_ROUTES,
   ...COMMUNITY_ROUTES,

--- a/src/shared/hook/useSimpleBottomSheet.ts
+++ b/src/shared/hook/useSimpleBottomSheet.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+const useSimpleBottomSheet = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openBottomSheet = () => setIsOpen(true);
+  const closeBottomSheet = () => setIsOpen(false);
+  const toggleBottomSheet = () => setIsOpen((prev) => !prev);
+
+  return { isOpen, openBottomSheet, closeBottomSheet, toggleBottomSheet };
+};
+
+export default useSimpleBottomSheet;


### PR DESCRIPTION
## 🔥 Related Issues

- close #90 

## ✅ 작업 리스트

- [x] SimpleBottomSheet 리팩토링
- [x] useSimpleBottomSheet() 훅 구현

## 🔧 작업 내용
간단하니까 생략

## 📣 리뷰어에게 어떠신가요?
사용 방법 - 이미지 참참고
1. SImpleBottomSheet import 해서 필요한 prop들 잘 넣어주기
2. useSimpleBottomSheet() 훅도 같이 받아와서 isOpen을 심플바텀시트 prop으로 넘겨줌

<img width="717" alt="image" src="https://github.com/user-attachments/assets/0d9bc7c4-ff6c-4631-95ce-624a2041c3c0" />



## 📸 스크린샷 / GIF / Link
없음