### PR TITLE
[feat/#106] 최근 검색어 GET api 연동 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "format": "biome format --write",
     "check": "biome check --write",
     "reporter": "biome check --reporter=summary",
-    "generate-types": "openapi-typescript http://3.35.148.64/v3/api-docs -o ./src/type/schema.d.ts"
-
+    "generate-types": "openapi-typescript https://www.cocos.r-e.kr/v3/api-docs -o ./src/type/schema.d.ts"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.11",

--- a/src/api/constants/apiPath.ts
+++ b/src/api/constants/apiPath.ts
@@ -1,17 +1,22 @@
 export const API_PATH = {
-  COMMENTS: "/api/dev/comments/",
-  SUBCOMMENTS: "/api/dev/comments/sub/",
+  COMMENTS: "/api/dev/comments",
+  SUBCOMMENTS: "/api/dev/comments/sub",
 
-  LIKE: "/api/dev/likes/",
-  BREEDS: "/api/dev/breeds/",
-  PETS: "/api/dev/pets/",
-  SYMPTOMS: "/api/dev/symptoms/",
-  SEARCH: "/api/dev/search/",
-  BODY: "/api/dev/bodies/",
-  DISEASE: "/api/dev/diseases/",
+  LIKE: "/api/dev/likes",
+  BREEDS: "/api/dev/breeds",
+  PETS: "/api/dev/pets",
+  SYMPTOMS: "/api/dev/symptoms",
+  SEARCH: "/api/dev/search",
+  BODY: "/api/dev/bodies",
+  DISEASE: "/api/dev/diseases",
 
-  POST: "/api/dev/posts/",
+  ANIMALS: "/api/dev/animals",
+
+  POST: "/api/dev/posts",
   POST_FILTERS: "/api/dev/posts/filters/",
-  POST_POPULAR: "/api/dev/posts/popular/",
-  POST_CATEGORIES: "/api/dev/posts/categories/",
+  POST_POPULAR: "/api/dev/posts/popular",
+  POST_CATEGORIES: "/api/dev/posts/categories",
+
+  TEST_HEALTH_CHECK: "/api/dev/test/health-check",
+  TEST_TOKEN_CHECK: "/api/dev/test/token-check",
 };

--- a/src/api/domain/community/post/hook.ts
+++ b/src/api/domain/community/post/hook.ts
@@ -1,0 +1,3 @@
+export const SEARCH_QUERY_KEY = {
+  SEARCH_QUERY_KEY: () => ["search"],
+};

--- a/src/api/domain/community/search/hook.ts
+++ b/src/api/domain/community/search/hook.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { SEARCH_QUERY_KEY } from "@api/domain/community/post/hook.ts";
+import { getSearch } from "@api/domain/community/search/index.ts";
+
+/**
+ * @description 최근 검색어 조회 API
+ */
+export const useSearchGet = () => {
+  return useQuery({
+    queryKey: SEARCH_QUERY_KEY.SEARCH_QUERY_KEY(),
+    queryFn: () => {
+      return getSearch();
+    },
+  });
+};

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -1,3 +1,5 @@
+import { API_PATH } from "@api/constants/apiPath";
+import { api } from "@api/index";
 import { paths } from "src/type/schema";
 
 type searchGetResponse =
@@ -5,29 +7,12 @@ type searchGetResponse =
 
 type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
 
-//아래와 같이 requset용 타입 , response용 타입으로 사용하는게 당장은 편해도 장기적인 유지 보수에는 불리.
-//따라서 아래와 같은 방식은 사용 x
-// import { components } from "@typings/api/schema";
-// export type PostCommentWithMentionRequest = components["schemas"]["PostCommentWithMentionRequest"];
+/**
+ * @description 최근 검색어 조회 API
+ * @param query
+ */
 
-// export type PostCommentWithMentionResponse = components["schemas"]["PostCommentWithMentionResponse"];
-
-/*
-    🐶🐶🐶🐶🐶get API를 위한 useQuery 작성 예시🐶🐶🐶🐶🐶
-    (스키마 사용 가정) - 만약 스키마가 없다면, get<PostCommentWithMentionRequest>과 같은 형식으로 응답값 타입 정의해서 사용할거임
-*/
-//1. api 함수를 작성한다
-// export const getPost = async (postId: string) => {
-//     type getPostType = paths['/post/v2/{postId}']['get']['responses']['200']['content']['application/json;charset=UTF-8'];
-//     const { data } = await get<getPostType>(`/post/v2/${postId}`);
-//     return data;
-//   };
-
-/*
-    🐱🐱🐱🐱🐱delete, post, put API를 위한 useMutation 작성 예시🐱🐱🐱🐱🐱
-    (스키마 사용 가정)
-*/
-//1. api 함수를 작성한다
-// export const deleteComment = async (commentId: number) => {
-//     return (await api.delete(`/comment/v2/${commentId}`)).data;
-//   };
+export const getSearch = async () => {
+  const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
+  return data.data;
+};

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -9,7 +9,6 @@ type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
 
 /**
  * @description 최근 검색어 조회 API
- * @param query
  */
 
 export const getSearch = async () => {

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -11,11 +11,6 @@ type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
  * @description 최근 검색어 조회 API
  */
 
-// export const getSearch = async () => {
-//   const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
-//   return data.data;
-// };
-
 export const getSearch = async () => {
   const { data } = await get<searchGetResponse>(API_PATH.SEARCH, {});
   return data.data;

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -17,6 +17,6 @@ type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
 // };
 
 export const getSearch = async () => {
-  const { data } = await api.get<searchGetResponse>(API_PATH.ANIMALS, {});
+  const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
   return data.data;
 };

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -1,5 +1,5 @@
 import { API_PATH } from "@api/constants/apiPath";
-import { api } from "@api/index";
+import { get } from "@api/index";
 import { paths } from "src/type/schema";
 
 type searchGetResponse =
@@ -17,6 +17,6 @@ type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
 // };
 
 export const getSearch = async () => {
-  const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
+  const { data } = await get<searchGetResponse>(API_PATH.SEARCH, {});
   return data.data;
 };

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -11,7 +11,12 @@ type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
  * @description 최근 검색어 조회 API
  */
 
+// export const getSearch = async () => {
+//   const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
+//   return data.data;
+// };
+
 export const getSearch = async () => {
-  const { data } = await api.get<searchGetResponse>(API_PATH.SEARCH, {});
+  const { data } = await api.get<searchGetResponse>(API_PATH.ANIMALS, {});
   return data.data;
 };

--- a/src/api/domain/community/search/index.ts
+++ b/src/api/domain/community/search/index.ts
@@ -1,18 +1,9 @@
-//아래는 예시입니다.
-//만약 스키마 사용 못할 경우, 아래와 같이 필요한 request body 타입 정의하기 (+ response 인터페이스도 정의하기)
-export interface PostCommentWithMentionRequest {
-  orgIds: number[] | null;
-  content: string;
-  postId: number;
-}
+import { paths } from "src/type/schema";
 
-export interface MeetingPeopleResponse {
-  requestBody: PostCommentWithMentionRequest;
-}
+type searchGetResponse =
+  paths["/api/dev/search"]["get"]["responses"]["200"]["content"]["*/*"];
 
-//⭐️!!스키마는 paths로 사용하기로 약속!!⭐️
-//import { paths } from "src/__generated__/schema;
-// type Post = paths['/post/v2']['get']['responses']['200']['content']['application/json;charset=UTF-8']['posts'];
+type searchPostRequest = paths["/api/dev/search"]["post"]["requestBody"];
 
 //아래와 같이 requset용 타입 , response용 타입으로 사용하는게 당장은 편해도 장기적인 유지 보수에는 불리.
 //따라서 아래와 같은 방식은 사용 x

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,7 +4,7 @@ const getAccessToken = (): string | null => {
   const user = localStorage.getItem("user");
   if (user) {
     const userObj = JSON.parse(user);
-    return userObj || "";
+    return userObj.accessToken || "";
   }
   return "";
 };

--- a/src/page/community/search/index/Search.tsx
+++ b/src/page/community/search/index/Search.tsx
@@ -12,7 +12,6 @@ const Search = () => {
   const query = searchParams.get("searchText");
   const [searchText, setSearchText] = useState(query || "");
   const { data: recentSearchData } = useSearchGet();
-  console.log(recentSearchData);
 
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/src/page/community/search/index/Search.tsx
+++ b/src/page/community/search/index/Search.tsx
@@ -35,7 +35,6 @@ const Search = () => {
   };
 
   useEffect(() => {
-    // 페이지 진입 시 TextField에 포커스 설정
     if (inputRef.current) {
       inputRef.current.focus();
     }

--- a/src/page/community/search/index/Search.tsx
+++ b/src/page/community/search/index/Search.tsx
@@ -11,7 +11,7 @@ const Search = () => {
   const [searchParams] = useSearchParams();
   const query = searchParams.get("searchText");
   const [searchText, setSearchText] = useState(query || "");
-  const { data: recentSearchData } = useSearchGet();
+  const { data: recentSearchData, isLoading } = useSearchGet();
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -40,6 +40,8 @@ const Search = () => {
     }
   }, []);
 
+  if (!recentSearchData || !recentSearchData.keywords || isLoading) return null;
+
   return (
     <div className={styles.container}>
       <div className={styles.searchHeader}>
@@ -57,7 +59,7 @@ const Search = () => {
       <div className={styles.searchContent}>
         <div className={styles.title}>최근 검색 기록</div>
         <ul className={styles.list}>
-          {recentSearchData?.keywords?.map((data) => (
+          {recentSearchData.keywords.map((data) => (
             <li
               key={data.id}
               className={styles.listItem}

--- a/src/page/community/search/index/Search.tsx
+++ b/src/page/community/search/index/Search.tsx
@@ -2,19 +2,21 @@ import { styles } from "@page/community/search/index/Search.css.ts";
 import { IcLeftarrow, IcSearch } from "@asset/svg";
 import { TextField } from "@common/component/TextField";
 import React, { ChangeEvent, useEffect, useRef, useState } from "react";
-import { recentSearchData } from "@shared/constant/recentSearchData.ts";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { PATH } from "@route/path.ts";
+import { useSearchGet } from "@api/domain/community/search/hook.ts";
 
 const Search = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const query = searchParams.get("searchText");
   const [searchText, setSearchText] = useState(query || "");
+  const { data: recentSearchData } = useSearchGet();
+  console.log(recentSearchData);
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const onSubmit = (searchText: string) => {
+  const onSubmit = (searchText: string | undefined) => {
     searchParams.set("searchText", searchText);
     navigate(`${PATH.COMMUNITY.SEARCH_DONE}?${searchParams.toString()}`);
   };
@@ -57,9 +59,12 @@ const Search = () => {
       <div className={styles.searchContent}>
         <div className={styles.title}>최근 검색 기록</div>
         <ul className={styles.list}>
-          {recentSearchData.map((data) => (
-            <li key={data.id} className={styles.listItem} onClick={() => onSubmit(data.text)}>
-              {data.text}
+          {recentSearchData?.keywords.map((data) => (
+            <li
+              className={styles.listItem}
+              onClick={() => onSubmit(data.content)}
+            >
+              {data.content}
             </li>
           ))}
         </ul>

--- a/src/page/community/search/index/Search.tsx
+++ b/src/page/community/search/index/Search.tsx
@@ -16,7 +16,7 @@ const Search = () => {
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const onSubmit = (searchText: string | undefined) => {
+  const onSubmit = (searchText: string) => {
     searchParams.set("searchText", searchText);
     navigate(`${PATH.COMMUNITY.SEARCH_DONE}?${searchParams.toString()}`);
   };
@@ -59,12 +59,15 @@ const Search = () => {
       <div className={styles.searchContent}>
         <div className={styles.title}>최근 검색 기록</div>
         <ul className={styles.list}>
-          {recentSearchData?.keywords.map((data) => (
+          {recentSearchData?.keywords?.map((data) => (
             <li
+              key={data.id}
               className={styles.listItem}
-              onClick={() => onSubmit(data.content)}
+              onClick={() => {
+                if (data.content) onSubmit(data.content);
+              }}
             >
-              {data.content}
+              {data.content || ""}
             </li>
           ))}
         </ul>

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -88,6 +88,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dev/members/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 로그아웃 API
+         * @description 로그아웃 API 입니다.
+         */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/members/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 로그인 API
+         * @description 로그인 API 입니다.
+         */
+        post: operations["login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dev/likes/{postId}": {
         parameters: {
             query?: never;
@@ -180,7 +220,47 @@ export interface paths {
         patch: operations["updatePet"];
         trace?: never;
     };
-    "/api/v1/test/token-check": {
+    "/api/dev/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사용자 조회 API
+         * @description 사용자를 조회하는 API 입니다.
+         */
+        get: operations["getMemberProfile"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 사용자 정보 업데이트 API
+         * @description 사용자를 정보 업데이트 API 입니다.
+         */
+        patch: operations["updateMemberProfile"];
+        trace?: never;
+    };
+    "/api/dev/test/token-valid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["tokenValid"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/test/token-check": {
         parameters: {
             query?: never;
             header?: never;
@@ -200,7 +280,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/test/health-check": {
+    "/api/dev/test/health-check": {
         parameters: {
             query?: never;
             header?: never;
@@ -254,6 +334,10 @@ export interface paths {
         get: operations["getPostDetail"];
         put?: never;
         post?: never;
+        /**
+         * 게시글 삭제 API
+         * @description 게시글을 삭제하는 API입니다.
+         */
         delete: operations["deletePost"];
         options?: never;
         head?: never;
@@ -272,6 +356,26 @@ export interface paths {
          * @description 인기 게시글을 조회하는 API입니다.
          */
         get: operations["getPopularPosts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/posts/my": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사용자 게시글 조회 API
+         * @description 사용자 게시글을 조회하는 API입니다.
+         */
+        get: operations["getMemberPosts"];
         put?: never;
         post?: never;
         delete?: never;
@@ -300,6 +404,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dev/members/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 토큰 재발급 API
+         * @description 토큰 재발급 API 입니다.
+         */
+        get: operations["reIssueToken"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dev/diseases": {
         parameters: {
             query?: never;
@@ -312,6 +436,26 @@ export interface paths {
          * @description 질병 리스트를 조회하는 API입니다.
          */
         get: operations["getDiseases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/comments/my": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 나의 댓글&대댓글 조회 API
+         * @description 내가 단 댓글과 대댓글을 조회하는 API입니다.
+         */
+        get: operations["getMyComments"];
         put?: never;
         post?: never;
         delete?: never;
@@ -655,6 +799,46 @@ export interface components {
              */
             symptomIds?: number[];
         };
+        LoginRequest: {
+            /**
+             * @description 소셜 플랫폼
+             * @example KAKAO
+             * @enum {string}
+             */
+            platform?: "KAKAO";
+            /**
+             * @description 코드
+             * @example egagasdgasdgdagdasgasgasdgdasgasdglkj
+             */
+            code?: string;
+        };
+        BaseResponseLoginResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["LoginResponse"];
+        };
+        LoginResponse: {
+            /** @description 토큰 */
+            token?: components["schemas"]["TokenResponse"];
+            /**
+             * @description 기존 멤버 여부
+             * @example false
+             */
+            isCompletedSignUp?: boolean;
+        };
+        TokenResponse: {
+            /**
+             * @description 어세스 토큰
+             * @example egwg.adgad.asdgas
+             */
+            accessToken?: string;
+            /**
+             * @description 리프레시 토큰
+             * @example egwg.adgad.asdgas
+             */
+            refreshToken?: string;
+        };
         CommentContentRequest: {
             /**
              * @description 댓글 내용
@@ -718,6 +902,15 @@ export interface components {
              *     ]
              */
             symptomIds?: number[];
+        };
+        BaseResponseNicknameExistenceResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["NicknameExistenceResponse"];
+        };
+        NicknameExistenceResponse: {
+            isExistNickname?: boolean;
         };
         BaseResponseSymptomsOfBodiesResponse: {
             /** Format: int32 */
@@ -884,6 +1077,80 @@ export interface components {
             /** @description 인기 게시글 리스트 */
             posts?: components["schemas"]["PopularPostResponse"][];
         };
+        BaseResponseMemberPostsResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberPostsResponse"];
+        };
+        MemberPostDetailResponse: {
+            /**
+             * Format: int64
+             * @description 게시글 아이디
+             * @example 1
+             */
+            id?: number;
+            nickname?: string;
+            /**
+             * @description 게시글 제목
+             * @example title
+             */
+            title?: string;
+            /**
+             * @description 게시글 내용
+             * @example content
+             */
+            content?: string;
+            /**
+             * Format: int32
+             * @description 게시글 좋아요 개수
+             * @example 1
+             */
+            likeCount?: number;
+            /**
+             * Format: int32
+             * @description 게시글 댓글 개수
+             * @example 1
+             */
+            commentCount?: number;
+            /**
+             * Format: date-time
+             * @description 게시글 생성일
+             * @example 1
+             */
+            createdAt?: string;
+            /**
+             * Format: date-time
+             * @description 게시글 수정일
+             * @example 1
+             */
+            updatedAt?: string;
+            /**
+             * @description 게시글 이미지
+             * @example 1
+             */
+            image?: string;
+            /**
+             * @description 게시글 카테고리
+             * @example 1
+             */
+            category?: string;
+            /**
+             * @description 반려동물 품종
+             * @example 포메라니안
+             */
+            breed?: string;
+            /**
+             * Format: int32
+             * @description 반려동물 나이
+             * @example 14
+             */
+            age?: number;
+        };
+        MemberPostsResponse: {
+            /** @description 사용자 게시글 리스트 */
+            posts?: components["schemas"]["MemberPostDetailResponse"][];
+        };
         BaseResponsePostCategoriesResponse: {
             /** Format: int32 */
             code?: number;
@@ -999,6 +1266,34 @@ export interface components {
              * @example 증상1
              */
             name?: string;
+        };
+        BaseResponseMemberProfileResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberProfileResponse"];
+        };
+        MemberProfileResponse: {
+            /**
+             * @description 닉네임
+             * @example 모모
+             */
+            nickname?: string;
+            /**
+             * @description 프로필 이미지
+             * @example http://~~
+             */
+            profileImage?: string;
+        };
+        BaseResponseReissueTokenResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["ReissueTokenResponse"];
+        };
+        ReissueTokenResponse: {
+            /** @description 토큰 */
+            tokens?: components["schemas"]["TokenResponse"];
         };
         BaseResponseDiseasesOfBodiesResponse: {
             /** Format: int32 */
@@ -1139,8 +1434,85 @@ export interface components {
              */
             isWriter?: boolean;
             /**
-             * @description 댓글 사용자 닉네임
-             * @example 언급 표시를 위한 사용자 닉네임입니다.
+             * @description 언급 표시를 위한 사용자 닉네임
+             * @example 빵빵이
+             */
+            mentionedNickname?: string;
+        };
+        BaseResponseMyAllCommentsResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MyAllCommentsResponse"];
+        };
+        MyAllCommentsResponse: {
+            /** @description 댓글 리스트 */
+            comments?: components["schemas"]["MyCommentResponse"][];
+            /** @description 대댓글 리스트 */
+            subComments?: components["schemas"]["MySubCommentResponse"][];
+        };
+        MyCommentResponse: {
+            /**
+             * Format: int64
+             * @description 댓글 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 댓글 내용
+             * @example content
+             */
+            content?: string;
+            /**
+             * Format: int64
+             * @description 게시글 아이디
+             * @example 1
+             */
+            postId?: number;
+            /**
+             * @description 게시글 제목
+             * @example 오늘 무슨 일이..
+             */
+            postTitle?: string;
+            /**
+             * Format: date-time
+             * @description 댓글 생성일
+             * @example 2025-01-01T00:00:00
+             */
+            createdAt?: string;
+        };
+        MySubCommentResponse: {
+            /**
+             * Format: int64
+             * @description 대댓글 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 대댓글 내용
+             * @example content
+             */
+            content?: string;
+            /**
+             * Format: int64
+             * @description 게시글 아이디
+             * @example 1
+             */
+            postId?: number;
+            /**
+             * @description 게시글 제목
+             * @example 오늘 무슨 일이..
+             */
+            postTitle?: string;
+            /**
+             * Format: date-time
+             * @description 대댓글 생성일
+             * @example 2025-01-01T00:00:00
+             */
+            createdAt?: string;
+            /**
+             * @description 언급 표시를 위한 사용자 닉네임
+             * @example 빵빵이
              */
             mentionedNickname?: string;
         };
@@ -1369,6 +1741,50 @@ export interface operations {
             };
         };
     };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 로그아웃에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseVoid"];
+                };
+            };
+        };
+    };
+    login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginRequest"];
+            };
+        };
+        responses: {
+            /** @description 로그인에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseLoginResponse"];
+                };
+            };
+        };
+    };
     addPostLike: {
         parameters: {
             query?: never;
@@ -1541,6 +1957,70 @@ export interface operations {
             };
         };
     };
+    getMemberProfile: {
+        parameters: {
+            query?: {
+                nickname?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 사용자 조회에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberProfileResponse"];
+                };
+            };
+        };
+    };
+    updateMemberProfile: {
+        parameters: {
+            query: {
+                nickname: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다.  */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseNicknameExistenceResponse"];
+                };
+            };
+        };
+    };
+    tokenValid: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
     tokenCheck: {
         parameters: {
             query?: never;
@@ -1670,6 +2150,29 @@ export interface operations {
             };
         };
     };
+    getMemberPosts: {
+        parameters: {
+            query?: {
+                /** @description 모모 */
+                nickname?: unknown;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 사용자 게시글 조회 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberPostsResponse"];
+                };
+            };
+        };
+    };
     getPostCategories: {
         parameters: {
             query?: never;
@@ -1686,6 +2189,26 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["BaseResponsePostCategoriesResponse"];
+                };
+            };
+        };
+    };
+    reIssueToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 토큰 재발급에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseReissueTokenResponse"];
                 };
             };
         };
@@ -1709,6 +2232,28 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["BaseResponseDiseasesOfBodiesResponse"];
+                };
+            };
+        };
+    };
+    getMyComments: {
+        parameters: {
+            query?: {
+                nickname?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMyAllCommentsResponse"];
                 };
             };
         };


### PR DESCRIPTION
## 🔥 Related Issues

- close #106 

## ✅ 작업 리스트

- [x] 최근 검색어 GET api 연동 
- [x] 쿼리 키 셋팅

## 🔧 작업 내용

쿼리 키 세팅 했습니다.


```typescript
/**
 * @description 최근 검색어 조회 API
 */
export const useSearchGet = () => {
  return useQuery({
    queryKey: SEARCH_QUERY_KEY.SEARCH_QUERY_KEY(),
    queryFn: () => {
      return getSearch();
    },
  });
};
```

다음과 같이 상수로 import 해서 사용하세요.
준혁오빠가 세팅한 거 보니까 쿼리키는 자기가 사용하는 쿼리키로 따로 만들어서 쓰더라구요!
저는 주로 아예 QUERY_KEY 를 하나의 객체로 그 안에 구성되도록 했었는데,
준혁 오빠 방법이 충돌도 적을 것 같아서 좋아 보입니다!
다들 어떻게 생각하는지 얘기해주시면 좋을 것 같아요

우선 제가 사용하는 SEARCH 는 파라미터가 없어서 

```typescript
export const SEARCH_QUERY_KEY = {
  SEARCH_QUERY_KEY: () => ["search"],
};

```

다음과 같이 세팅해두었습니다.

## 📣 리뷰어에게 어떠신가요?

이거 아직 서버 CORS 에러 해결해야해서 그거 확인하고 코리 달아주시면 좋을 것 같아요 
🚨 아직 아님 🚨

## 📸 스크린샷 / GIF / Link
<img width="359" alt="스크린샷 2025-01-18 18 08 12" src="https://github.com/user-attachments/assets/6c724c75-702b-4782-bc5e-55b85cef254a" />
