### PR TITLE
[Feat/#142] 닉네임 조회 api 

### DIFF
--- a/src/api/domain/complete/hook.ts
+++ b/src/api/domain/complete/hook.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getNickname } from ".";
+
+export const NICKNAME_QUERY_KEY = {
+  NICKNAME_QUERY_KEY: () => ["nickname"],
+};
+
+export const useGetNickname = () => {
+  return useQuery({
+    queryKey: NICKNAME_QUERY_KEY.NICKNAME_QUERY_KEY(),
+    queryFn: () => {
+      return getNickname();
+    },
+  });
+};

--- a/src/api/domain/complete/index.ts
+++ b/src/api/domain/complete/index.ts
@@ -1,0 +1,10 @@
+import { paths } from "@type/schema";
+import { API_PATH } from "@api/constants/apiPath";
+import { get } from "@api/index";
+
+export type nicknameGetResponse = paths["/api/dev/members"]["get"]["responses"]["200"]["content"]["*/*"];
+
+export const getNickname = async () => {
+  const { data } = await get<nicknameGetResponse>(API_PATH.MEMBERS, {});
+  return data.data;
+};

--- a/src/page/onboarding/complete/Complete.tsx
+++ b/src/page/onboarding/complete/Complete.tsx
@@ -19,13 +19,14 @@ const Complete = () => {
 
   // api
   const { data: nickname } = useGetNickname();
+  if (!nickname) return;
 
   return (
     <div className={styles.backGround}>
       <div className={styles.layout}>
         <div className={styles.titleWrapper}>
           <div>
-            <Title text={`${nickname?.nickname}님`} />
+            <Title text={`${nickname.nickname}님`} />
             <Title text={"반려동물을 등록해 주세요"} />
           </div>
           <Docs text={"작은 정보가 우리 아이의 건강을 지켜요"} />

--- a/src/page/onboarding/complete/Complete.tsx
+++ b/src/page/onboarding/complete/Complete.tsx
@@ -5,6 +5,7 @@ import Title from "../index/common/title/Title";
 import { Button } from "@common/component/Button";
 import img from "@asset/image/beforeRegisterGraphic.png";
 import { PATH } from "@route/path";
+import { useGetNickname } from "@api/domain/complete/hook";
 
 const Complete = () => {
   const navigate = useNavigate();
@@ -16,12 +17,15 @@ const Complete = () => {
     navigate(PATH.REGISTER_PET.ROOT);
   };
 
+  // api
+  const { data: nickname } = useGetNickname();
+
   return (
     <div className={styles.backGround}>
       <div className={styles.layout}>
         <div className={styles.titleWrapper}>
           <div>
-            <Title text={"@@@님"} />
+            <Title text={`${nickname?.nickname}님`} />
             <Title text={"반려동물을 등록해 주세요"} />
           </div>
           <Docs text={"작은 정보가 우리 아이의 건강을 지켜요"} />

--- a/src/page/registerPet/complete/Complete.tsx
+++ b/src/page/registerPet/complete/Complete.tsx
@@ -5,18 +5,23 @@ import Title from "@page/onboarding/index/common/title/Title";
 import { Button } from "@common/component/Button";
 import img from "@asset/image/beforeRegisterGraphic.png";
 import { PATH } from "@route/path";
+import { useGetNickname } from "@api/domain/complete/hook";
+
 const Complete = () => {
   const navigate = useNavigate();
   const handleSkip = () => {
     navigate(PATH.MAIN);
   };
 
+  // api
+  const { data: nickname } = useGetNickname();
+
   return (
     <div className={styles.backGround}>
       <div className={styles.layout}>
         <div className={styles.titleWrapper}>
           <div>
-            <Title text={"@@@님"} />
+            <Title text={`${nickname?.nickname}님`} />
             <Title text={"등록이 완료되었습니다"} />
           </div>
           <Docs text={"반려동물과 함께하는 긴 시간, 더 잘 돌봐드릴게요"} />


### PR DESCRIPTION
## 🔥 Related Issues

- close #142 

## ✅ 작업 리스트

- [x] 온보딩 완료 뷰 닉네임 조회 api 연동
- [x] 반려동물 등록 완료 뷰 닉네임 조회 api 연동


## 🔧 작업 내용

온보딩과 반려동물 등록 마지막에 나오는 닉네임 api 연동했습니다.


## 📸 스크린샷 / GIF / Link
- 구현화면 (온보딩, 반려동물 등록)
<img width="395" alt="스크린샷 2025-01-22 오전 4 25 27" src="https://github.com/user-attachments/assets/007d98f3-b794-449a-a7b6-b84161acd070" />

<img width="396" alt="스크린샷 2025-01-22 오전 4 26 38" src="https://github.com/user-attachments/assets/437a3aee-d5f2-4782-81f3-2f4cf63537e6" />
