### PR TITLE
[Feat/#135] 게시물 삭제 api , 댓글 삭제 api, 대댓글 삭제 api 연동

### DIFF
--- a/src/api/domain/community/post/hook.ts
+++ b/src/api/domain/community/post/hook.ts
@@ -16,14 +16,8 @@ export const POST_QUERY_KEY = {
 
 export const COMMENT_QUERY_KEY = {
   COMMENTS_QUERY_KEY: (postId: number) => ["comments", postId],
-  DELETE_COMMENT: (commentId: number | undefined) => [
-    "deleteComment",
-    commentId,
-  ],
-  DELETE_SUB_COMMENT: (subCommentId: number | undefined) => [
-    "deleteSubComment",
-    subCommentId,
-  ],
+  DELETE_COMMENT: (commentId: number | undefined) => ["deleteComment", commentId],
+  DELETE_SUB_COMMENT: (subCommentId: number | undefined) => ["deleteSubComment", subCommentId],
 };
 
 /**
@@ -87,9 +81,9 @@ export const useCommentsGet = (postId: number) => {
 export const useDeleteComment = (commentId: number | undefined) => {
   return useMutation({
     mutationKey: COMMENT_QUERY_KEY.DELETE_COMMENT(commentId),
-    mutationFn: () => {
-      console.log("commentId", commentId);
-      // return deleteComment(commentId);
+    mutationFn: (commentId: number) => {
+      // return console.log("commentId", commentId);
+      return deleteComment(commentId);
     },
   });
 };

--- a/src/api/domain/community/post/hook.ts
+++ b/src/api/domain/community/post/hook.ts
@@ -1,11 +1,29 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { getComments, deleteLike, getPost, postLike } from "@api/domain/community/post";
+import {
+  deleteComment,
+  getComments,
+  deleteLike,
+  getPost,
+  postLike,
+  deleteSubComment,
+} from "@api/domain/community/post";
 
 export const POST_QUERY_KEY = {
   POST_QUERY_KEY: (postId: number) => ["post", postId],
-  COMMENTS_QUERY_KEY: (postId: number) => ["comments", postId],
   LIKE_POST_QUERY_KEY: (postId: string) => ["like", postId],
   LIKE_DELETE_QUERY_KEY: (postId: string) => ["likeDelete", postId],
+};
+
+export const COMMENT_QUERY_KEY = {
+  COMMENTS_QUERY_KEY: (postId: number) => ["comments", postId],
+  DELETE_COMMENT: (commentId: number | undefined) => [
+    "deleteComment",
+    commentId,
+  ],
+  DELETE_SUB_COMMENT: (subCommentId: number | undefined) => [
+    "deleteSubComment",
+    subCommentId,
+  ],
 };
 
 /**
@@ -55,9 +73,38 @@ export const useDeleteLike = (postId: string) => {
 
 export const useCommentsGet = (postId: number) => {
   return useQuery({
-    queryKey: POST_QUERY_KEY.COMMENTS_QUERY_KEY(postId),
+    queryKey: COMMENT_QUERY_KEY.COMMENTS_QUERY_KEY(postId),
     queryFn: () => {
       return getComments(postId);
+    },
+  });
+};
+
+/**
+ * @description 댓글 삭제 API
+ */
+
+export const useDeleteComment = (commentId: number | undefined) => {
+  return useMutation({
+    mutationKey: COMMENT_QUERY_KEY.DELETE_COMMENT(commentId),
+    mutationFn: () => {
+      console.log("commentId", commentId);
+      // return deleteComment(commentId);
+    },
+  });
+};
+
+/**
+ * @description 대댓글 삭제 API
+ */
+
+export const useDeleteSubComment = (subCommentId: number | undefined) => {
+  return useMutation({
+    mutationKey: COMMENT_QUERY_KEY.DELETE_SUB_COMMENT(subCommentId),
+    mutationFn: () => {
+      console.log("subCommentId", subCommentId);
+
+      return deleteSubComment(subCommentId);
     },
   });
 };

--- a/src/api/domain/community/post/hook.ts
+++ b/src/api/domain/community/post/hook.ts
@@ -116,7 +116,6 @@ export const useDeleteSubComment = (subCommentId: number | undefined) => {
   return useMutation({
     mutationKey: COMMENT_QUERY_KEY.DELETE_SUB_COMMENT(subCommentId),
     mutationFn: () => {
-      // console.log("deleteSubComment");
       return deleteSubComment(subCommentId);
     },
     onSuccess: () => {

--- a/src/api/domain/community/post/hook.ts
+++ b/src/api/domain/community/post/hook.ts
@@ -6,8 +6,10 @@ import {
   getPost,
   postLike,
   deleteSubComment,
+  deletePost,
 } from "@api/domain/community/post";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import { PATH } from "@route/path.ts";
 
 export const POST_QUERY_KEY = {
   POST_QUERY_KEY: (postId: number) => ["post", postId],
@@ -77,6 +79,22 @@ export const useCommentsGet = (postId: number) => {
     queryKey: COMMENT_QUERY_KEY.COMMENTS_QUERY_KEY(postId),
     queryFn: () => {
       return getComments(postId);
+    },
+  });
+};
+
+/**
+ * @description 게시글 삭제 API
+ */
+export const usePostDelete = (postId: number) => {
+  const navigate = useNavigate();
+  return useMutation({
+    mutationKey: POST_QUERY_KEY.POST_QUERY_KEY(postId),
+    mutationFn: (postId: number) => {
+      return deletePost(postId);
+    },
+    onSuccess: () => {
+      navigate(-1);
     },
   });
 };

--- a/src/api/domain/community/post/index.ts
+++ b/src/api/domain/community/post/index.ts
@@ -70,6 +70,18 @@ export const deleteSubComment = async (subCommentId: number | undefined) => {
 };
 
 /**
+ * @description 게시글 삭제 API
+ */
+
+export type deletePostResponse =
+  paths["/api/dev/posts/{postId}"]["delete"]["responses"]["200"]["content"]["*/*"];
+
+export const deletePost = async (postId: number) => {
+  const { data } = await del<deletePostResponse>(`${API_PATH.POST}/${postId}`);
+  return data.data;
+};
+
+/**
  * @description 좋아요 추가 API
  * @param postId
  */

--- a/src/api/domain/community/post/index.ts
+++ b/src/api/domain/community/post/index.ts
@@ -42,6 +42,34 @@ export const getComments = async (postId: number) => {
 };
 
 /**
+ * @description 댓글 삭제 API
+ */
+
+export type deleteCommentResponse =
+  paths["/api/dev/comments/{commentId}"]["delete"]["responses"]["200"]["content"]["*/*"];
+
+export const deleteComment = async (commentId: number | undefined) => {
+  const { data } = await del<deleteCommentResponse>(
+    `${API_PATH.COMMENTS}/${commentId}`
+  );
+  return data.data;
+};
+
+/**
+ * @description 대댓글 삭제 API
+ */
+
+export type deleteSubCommentResponse =
+  paths["/api/dev/comments/sub/{subCommentId}"]["delete"]["responses"]["200"]["content"]["*/*"];
+
+export const deleteSubComment = async (subCommentId: number | undefined) => {
+  const { data } = await del<deleteSubCommentResponse>(
+    `${API_PATH.SUBCOMMENTS}/${subCommentId}`
+  );
+  return data.data;
+};
+
+/**
  * @description 좋아요 추가 API
  * @param postId
  */

--- a/src/api/domain/community/post/index.ts
+++ b/src/api/domain/community/post/index.ts
@@ -76,6 +76,7 @@ export const deleteSubComment = async (subCommentId: number | undefined) => {
 
 type likePostResponse =
   paths["/api/dev/likes/{postId}"]["post"]["responses"]["204"]["content"]["*/*"];
+
 export const postLike = async (postId: string) => {
   const { data } = await post<likePostResponse>(`${API_PATH.LIKE}/${postId}`);
   return data;
@@ -87,6 +88,7 @@ export const postLike = async (postId: string) => {
 
 type likeDeleteResponse =
   paths["/api/dev/likes/{postId}"]["delete"]["responses"]["204"]["content"]["*/*"];
+
 export const deleteLike = async (postId: string) => {
   const { data } = await del<likeDeleteResponse>(`${API_PATH.LIKE}/${postId}`);
   return data;

--- a/src/common/component/Comment/Comment.tsx
+++ b/src/common/component/Comment/Comment.tsx
@@ -1,19 +1,13 @@
 import * as styles from "./Comment.css";
-import { IcEllipses, IcMessage } from "@asset/svg";
+import { IcMessage } from "@asset/svg";
 import SubCommentList from "../SubComment/SubCommentList";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import useModalStore from "@store/moreModalStore.ts";
-import {
-  commentGetResponseCommentType,
-  deleteComment,
-} from "@api/domain/community/post";
-import {
-  useDeleteComment,
-  useDeleteSubComment,
-} from "@api/domain/community/post/hook.ts";
+import { commentGetResponseCommentType } from "@api/domain/community/post";
+import { useDeleteComment } from "@api/domain/community/post/hook.ts";
 import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
-import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet.tsx";
 import { formatTime } from "@shared/util/formatTime.ts";
+import SimpleBottomSheet from "../SimpleBottomSheet/SimpleBottomSheet";
 
 interface CommentProps {
   comment: commentGetResponseCommentType;
@@ -32,8 +26,8 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
   const { mutate: deleteComment } = useDeleteComment(comment.id);
 
   // @공준혁 : 댓글 삭제 버튼 클릭시 subcomment 로 보내줄 함수입니다.
-  const onDeleteClick = () => {
-    deleteComment();
+  const onDeleteClick = (id: number) => {
+    deleteComment(id);
     console.log("deleteComment");
     setOpen(false);
   };
@@ -44,16 +38,11 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
     <div className={styles.commentItem}>
       <div className={styles.contentContainer}>
         <div className={styles.header}>
-          <img
-            src={comment.profileImage}
-            className={styles.profileImage}
-            alt="프로필 이미지"
-          />
+          <img src={comment.profileImage} className={styles.profileImage} alt="프로필 이미지" />
           <div className={styles.headerInfo}>
             <span className={styles.nickname}>{comment.nickname}</span>
             <span className={styles.meta}>
-              {comment.breed} · {comment.petAge}살 ·{" "}
-              {comment.createdAt ? formatTime(comment.createdAt) : ""}
+              {comment.breed} · {comment.petAge}살 · {comment.createdAt ? formatTime(comment.createdAt) : ""}
             </span>
           </div>
           <MoreModal
@@ -79,24 +68,20 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
       {/* 대댓글 리스트 */}
       {comment.subComments && (
         <div>
-          <SubCommentList
-            subComments={comment.subComments}
-            onCommentDelete={() => onDeleteClick()}
-          />
+          <SubCommentList subComments={comment.subComments} onCommentDelete={onDeleteClick} />
         </div>
       )}
-      {/*<SimpleBottomSheet*/}
-      {/*  isOpen={isOpen}*/}
-      {/*  content={"댓글을 정말 삭제할까요?"}*/}
-      {/*  handleClose={() => setOpen(false)}*/}
-      {/*  leftOnClick={() => setOpen(false)}*/}
-      {/*  leftText={"취소"}*/}
-      {/*  rightOnClick={() => {*/}
-      {/*    onDeleteClick();*/}
-      {/*    console.log("deleteSubComment");*/}
-      {/*  }}*/}
-      {/*  rightText={"삭제할게요"}*/}
-      {/*/>*/}
+      <SimpleBottomSheet
+        isOpen={isOpen}
+        content={"댓글을 정말 삭제할까요?"}
+        handleClose={() => setOpen(false)}
+        leftOnClick={() => setOpen(false)}
+        leftText={"취소"}
+        rightOnClick={() => {
+          onDeleteClick(comment.id as number);
+        }}
+        rightText={"삭제할게요"}
+      />
     </div>
   );
 };

--- a/src/common/component/Comment/Comment.tsx
+++ b/src/common/component/Comment/Comment.tsx
@@ -9,7 +9,7 @@ import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilt
 import { formatTime } from "@shared/util/formatTime.ts";
 import SimpleBottomSheet from "../SimpleBottomSheet/SimpleBottomSheet";
 import { useParams } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 interface CommentProps {
   comment: commentGetResponseCommentType;
@@ -24,20 +24,16 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
   };
 
   if (!comment) return;
-  const { isOpen, setOpen, setContentsType, contentsType } =
-    useCategoryFilterStore();
+  const { setContentsType } = useCategoryFilterStore();
+  const [isOpen, setOpen] = useState(false);
   const { mutate: deleteComment } = useDeleteComment(comment.id);
   const { openModalId, setOpenModalId } = useModalStore();
 
   const onDeleteClick = (id: number) => {
     deleteComment(id);
-    console.log("deleteComment");
+    console.log("deleteComment", id);
     setOpen(false);
   };
-
-  useEffect(() => {
-    console.log("콘텐츠 타입", contentsType);
-  }, [contentsType]);
 
   return (
     <div className={styles.commentItem}>

--- a/src/common/component/Comment/Comment.tsx
+++ b/src/common/component/Comment/Comment.tsx
@@ -3,20 +3,39 @@ import { IcEllipses, IcMessage } from "@asset/svg";
 import SubCommentList from "../SubComment/SubCommentList";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import useModalStore from "@store/moreModalStore.ts";
-import { commentGetResponseCommentType } from "@api/domain/community/post";
-import { components } from "@type/schema";
+import {
+  commentGetResponseCommentType,
+  deleteComment,
+} from "@api/domain/community/post";
+import {
+  useDeleteComment,
+  useDeleteSubComment,
+} from "@api/domain/community/post/hook.ts";
+import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
+import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet.tsx";
+import { formatTime } from "@shared/util/formatTime.ts";
 
 interface CommentProps {
   comment: commentGetResponseCommentType;
   onReplyClick?: (id: number | undefined) => void;
-  onDelete: () => void;
 }
 
-const Comment = ({ comment, onReplyClick, onDelete }: CommentProps) => {
+const Comment = ({ comment, onReplyClick }: CommentProps) => {
   const handleReplyClick = () => {
     if (onReplyClick) {
       onReplyClick(comment.id);
     }
+  };
+
+  if (!comment) return;
+  const { isOpen, setOpen, setContentsType } = useCategoryFilterStore();
+  const { mutate: deleteComment } = useDeleteComment(comment.id);
+
+  // @공준혁 : 댓글 삭제 버튼 클릭시 subcomment 로 보내줄 함수입니다.
+  const onDeleteClick = () => {
+    deleteComment();
+    console.log("deleteComment");
+    setOpen(false);
   };
 
   const { openModalId, setOpenModalId } = useModalStore();
@@ -34,11 +53,14 @@ const Comment = ({ comment, onReplyClick, onDelete }: CommentProps) => {
             <span className={styles.nickname}>{comment.nickname}</span>
             <span className={styles.meta}>
               {comment.breed} · {comment.petAge}살 ·{" "}
-              {comment.createdAt ? comment.createdAt.toLocaleString() : ""}
+              {comment.createdAt ? formatTime(comment.createdAt) : ""}
             </span>
           </div>
           <MoreModal
-            onDelete={onDelete}
+            onDelete={() => {
+              setOpen(true);
+              // setContentsType("comment");
+            }}
             iconSize={24}
             isOpen={openModalId === `comment-${comment.id}`}
             onToggleModal={() => setOpenModalId(`comment-${comment.id}`)}
@@ -57,9 +79,24 @@ const Comment = ({ comment, onReplyClick, onDelete }: CommentProps) => {
       {/* 대댓글 리스트 */}
       {comment.subComments && (
         <div>
-          <SubCommentList subComments={comment.subComments} />
+          <SubCommentList
+            subComments={comment.subComments}
+            onCommentDelete={() => onDeleteClick()}
+          />
         </div>
       )}
+      {/*<SimpleBottomSheet*/}
+      {/*  isOpen={isOpen}*/}
+      {/*  content={"댓글을 정말 삭제할까요?"}*/}
+      {/*  handleClose={() => setOpen(false)}*/}
+      {/*  leftOnClick={() => setOpen(false)}*/}
+      {/*  leftText={"취소"}*/}
+      {/*  rightOnClick={() => {*/}
+      {/*    onDeleteClick();*/}
+      {/*    console.log("deleteSubComment");*/}
+      {/*  }}*/}
+      {/*  rightText={"삭제할게요"}*/}
+      {/*/>*/}
     </div>
   );
 };

--- a/src/common/component/Comment/Comment.tsx
+++ b/src/common/component/Comment/Comment.tsx
@@ -8,6 +8,8 @@ import { useDeleteComment } from "@api/domain/community/post/hook.ts";
 import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
 import { formatTime } from "@shared/util/formatTime.ts";
 import SimpleBottomSheet from "../SimpleBottomSheet/SimpleBottomSheet";
+import { useParams } from "react-router-dom";
+import { useEffect } from "react";
 
 interface CommentProps {
   comment: commentGetResponseCommentType;
@@ -22,33 +24,41 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
   };
 
   if (!comment) return;
-  const { isOpen, setOpen, setContentsType } = useCategoryFilterStore();
+  const { isOpen, setOpen, setContentsType, contentsType } =
+    useCategoryFilterStore();
   const { mutate: deleteComment } = useDeleteComment(comment.id);
+  const { openModalId, setOpenModalId } = useModalStore();
 
-  // @공준혁 : 댓글 삭제 버튼 클릭시 subcomment 로 보내줄 함수입니다.
   const onDeleteClick = (id: number) => {
     deleteComment(id);
     console.log("deleteComment");
     setOpen(false);
   };
 
-  const { openModalId, setOpenModalId } = useModalStore();
+  useEffect(() => {
+    console.log("콘텐츠 타입", contentsType);
+  }, [contentsType]);
 
   return (
     <div className={styles.commentItem}>
       <div className={styles.contentContainer}>
         <div className={styles.header}>
-          <img src={comment.profileImage} className={styles.profileImage} alt="프로필 이미지" />
+          <img
+            src={comment.profileImage}
+            className={styles.profileImage}
+            alt="프로필 이미지"
+          />
           <div className={styles.headerInfo}>
             <span className={styles.nickname}>{comment.nickname}</span>
             <span className={styles.meta}>
-              {comment.breed} · {comment.petAge}살 · {comment.createdAt ? formatTime(comment.createdAt) : ""}
+              {comment.breed} · {comment.petAge}살 ·{" "}
+              {comment.createdAt ? formatTime(comment.createdAt) : ""}
             </span>
           </div>
           <MoreModal
             onDelete={() => {
               setOpen(true);
-              // setContentsType("comment");
+              setContentsType("comment");
             }}
             iconSize={24}
             isOpen={openModalId === `comment-${comment.id}`}
@@ -68,7 +78,10 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
       {/* 대댓글 리스트 */}
       {comment.subComments && (
         <div>
-          <SubCommentList subComments={comment.subComments} onCommentDelete={onDeleteClick} />
+          <SubCommentList
+            subComments={comment.subComments}
+            onCommentDelete={onDeleteClick}
+          />
         </div>
       )}
       <SimpleBottomSheet

--- a/src/common/component/Comment/Comment.tsx
+++ b/src/common/component/Comment/Comment.tsx
@@ -8,7 +8,6 @@ import { useDeleteComment } from "@api/domain/community/post/hook.ts";
 import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
 import { formatTime } from "@shared/util/formatTime.ts";
 import SimpleBottomSheet from "../SimpleBottomSheet/SimpleBottomSheet";
-import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 
 interface CommentProps {
@@ -31,7 +30,6 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
 
   const onDeleteClick = (id: number) => {
     deleteComment(id);
-    console.log("deleteComment", id);
     setOpen(false);
   };
 
@@ -73,7 +71,7 @@ const Comment = ({ comment, onReplyClick }: CommentProps) => {
 
       {/* 대댓글 리스트 */}
       {comment.subComments && (
-        <div>
+        <div style={{ width: "100%" }}>
           <SubCommentList
             subComments={comment.subComments}
             onCommentDelete={onDeleteClick}

--- a/src/common/component/Comment/CommentList.tsx
+++ b/src/common/component/Comment/CommentList.tsx
@@ -6,10 +6,6 @@ interface CommentListProps {
 }
 
 const CommentList = ({ comments }: CommentListProps) => {
-  const onDelete = (id?: number) => {
-    // TODO :  댓글 삭제
-  };
-
   const onReplyClick = (id?: number) => {
     // TODO : 대댓글 작성
   };
@@ -20,7 +16,6 @@ const CommentList = ({ comments }: CommentListProps) => {
         <Comment
           key={comment.id}
           comment={comment}
-          onDelete={() => onDelete(comment.id)}
           onReplyClick={() => onReplyClick(comment.id)}
         />
       ))}

--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.css.ts
@@ -2,7 +2,7 @@ import { style } from "@vanilla-extract/css";
 import { color, font, semanticColor } from "@style/styles.css";
 
 export const overlay = style({
-  position: "absolute",
+  position: "fixed",
   top: 0,
   left: 0,
   zIndex: "99",
@@ -15,9 +15,8 @@ export const overlay = style({
 export const bottomSheetContainer = style({
   position: "absolute",
   bottom: "0",
-
+  width: "100%",
   display: "flex",
-  width: "37.5rem",
   flexDirection: "column",
   justifyContent: "center",
   alignItems: "center",
@@ -38,7 +37,7 @@ export const bottomSheetHeader = style({
 
 export const contentContainer = style({
   display: "flex",
-  width: "33.5rem",
+  width: "90%",
   padding: "2rem 0rem 3.2rem 0rem",
   flexDirection: "column",
   alignItems: "flex-start",

--- a/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
+++ b/src/common/component/SimpleBottomSheet/SimpleBottomSheet.tsx
@@ -32,7 +32,10 @@ const SimpleBottomSheet = ({
 
   return (
     <div className={styles.overlay} onClick={handleClose}>
-      <div className={styles.bottomSheetContainer} onClick={handleBottomSheetClick}>
+      <div
+        className={styles.bottomSheetContainer}
+        onClick={handleBottomSheetClick}
+      >
         <div className={styles.bottomSheetHeader}>
           <IcBottomSheetLine width={80} onClick={handleClose} />
         </div>
@@ -43,7 +46,13 @@ const SimpleBottomSheet = ({
             {subContent && <p className={styles.subContent}>{subContent}</p>}
           </div>
           <div className={styles.buttonContainer}>
-            <Button label={`${leftText}`} size="large" variant="solidNeutral" disabled={false} onClick={leftOnClick} />
+            <Button
+              label={`${leftText}`}
+              size="large"
+              variant="solidNeutral"
+              disabled={false}
+              onClick={leftOnClick}
+            />
             <Button
               label={`${rightText}`}
               size="large"

--- a/src/common/component/SubComment/SubComment.css.ts
+++ b/src/common/component/SubComment/SubComment.css.ts
@@ -7,6 +7,7 @@ export const commentItem = style([
     alignItems: "flex-start",
     gap: "0.4rem",
     marginLeft: "4rem",
+    width: "calc(100% - 4rem)",
   },
 ]);
 

--- a/src/common/component/SubComment/SubComment.tsx
+++ b/src/common/component/SubComment/SubComment.tsx
@@ -1,28 +1,20 @@
 import * as styles from "./SubComment.css";
-import { IcEllipses, IcMessage } from "@asset/svg";
+import { IcMessage } from "@asset/svg";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import useModalStore from "@store/moreModalStore.ts";
 import { commentGetRequestSubCommentType } from "@api/domain/community/post";
 import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet.tsx";
-import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
-import {
-  useDeleteComment,
-  useDeleteSubComment,
-} from "@api/domain/community/post/hook.ts";
+import { useDeleteSubComment } from "@api/domain/community/post/hook.ts";
 import { formatTime } from "@shared/util/formatTime.ts";
-import { useEffect } from "react";
+import { useState } from "react";
 
 interface SubCommentProps {
   subComment: commentGetRequestSubCommentType;
   onReplyClick?: (id: number | undefined) => void;
-  onCommentDelete?: () => void;
+  onCommentDelete: () => void;
 }
 
-const SubComment = ({
-  subComment,
-  onReplyClick,
-  onCommentDelete,
-}: SubCommentProps) => {
+const SubComment = ({ subComment, onReplyClick, onCommentDelete }: SubCommentProps) => {
   const handleReplyClick = () => {
     if (onReplyClick) {
       onReplyClick(subComment.id);
@@ -31,8 +23,8 @@ const SubComment = ({
   const { mutate: deleteSubComment } = useDeleteSubComment(subComment.id);
 
   const { openModalId, setOpenModalId } = useModalStore();
-  const { isOpen, setOpen, setContentsType, contentsType } =
-    useCategoryFilterStore();
+  // const { isOpen, setOpen, setContentsType, contentsType } = useCategoryFilterStore();
+  const [isOpen, setIsOpen] = useState(false);
 
   const renderContent = () => {
     const { content, mentionedNickname } = subComment;
@@ -50,33 +42,17 @@ const SubComment = ({
       </>
     );
   };
-  useEffect(() => {
-    console.log("contentsType", contentsType);
-  }, [contentsType]);
+  // useEffect(() => {
+  //   console.log("contentsType", contentsType);
+  // }, [contentsType]);
 
   // @공준혁 : 대댓글 or 댓글 삭제 버튼 클릭시 api 호출부 입니다.
-  const onDeleteClick = () => {
-    console.log("deleteSubComment");
-
-    if (contentsType == "subComment") {
-      deleteSubComment();
-    } else {
-      if (onCommentDelete) {
-        onCommentDelete();
-      }
-    }
-    setOpen(false);
-  };
 
   return (
     <div className={styles.commentItem}>
       <div className={styles.contentContainer}>
         <div className={styles.header}>
-          <img
-            src={subComment.profileImage}
-            className={styles.profileImage}
-            alt="프로필 이미지"
-          />
+          <img src={subComment.profileImage} className={styles.profileImage} alt="프로필 이미지" />
           <div className={styles.headerInfo}>
             <span className={styles.nickname}>{subComment.nickname}</span>
             <span className={styles.meta}>
@@ -88,8 +64,8 @@ const SubComment = ({
             iconSize={24}
             onDelete={() => {
               console.log("deleteSubComment");
-              setOpen(true);
-              setContentsType("subComment");
+              setIsOpen(true);
+              // setContentsType("subComment");
             }}
             isOpen={openModalId === `subComment-${subComment.id}`}
             onToggleModal={() => setOpenModalId(`subComment-${subComment.id}`)}
@@ -105,13 +81,13 @@ const SubComment = ({
       </div>
       <SimpleBottomSheet
         isOpen={isOpen}
-        content={"댓글을 정말 삭제할까요?"}
-        handleClose={() => setOpen(false)}
-        leftOnClick={() => setOpen(false)}
+        content={"대댓글을 정말 삭제할까요?"}
+        handleClose={() => setIsOpen(false)}
+        leftOnClick={() => setIsOpen(false)}
         leftText={"취소"}
         rightOnClick={() => {
-          onDeleteClick();
-          console.log("deleteSubComment");
+          onCommentDelete();
+          setIsOpen(false);
         }}
         rightText={"삭제할게요"}
       />

--- a/src/common/component/SubComment/SubComment.tsx
+++ b/src/common/component/SubComment/SubComment.tsx
@@ -7,6 +7,7 @@ import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomS
 import { useDeleteSubComment } from "@api/domain/community/post/hook.ts";
 import { formatTime } from "@shared/util/formatTime.ts";
 import { useState } from "react";
+import { useCategoryFilterStore } from "@page/mypage/edit-pet/store/categoryFilter.ts";
 
 interface SubCommentProps {
   subComment: commentGetRequestSubCommentType;
@@ -14,16 +15,20 @@ interface SubCommentProps {
   onCommentDelete: () => void;
 }
 
-const SubComment = ({ subComment, onReplyClick, onCommentDelete }: SubCommentProps) => {
+const SubComment = ({
+  subComment,
+  onReplyClick,
+  onCommentDelete,
+}: SubCommentProps) => {
   const handleReplyClick = () => {
     if (onReplyClick) {
       onReplyClick(subComment.id);
     }
   };
   const { mutate: deleteSubComment } = useDeleteSubComment(subComment.id);
+  const { setContentsType, contentsType } = useCategoryFilterStore();
 
   const { openModalId, setOpenModalId } = useModalStore();
-  // const { isOpen, setOpen, setContentsType, contentsType } = useCategoryFilterStore();
   const [isOpen, setIsOpen] = useState(false);
 
   const renderContent = () => {
@@ -42,17 +47,16 @@ const SubComment = ({ subComment, onReplyClick, onCommentDelete }: SubCommentPro
       </>
     );
   };
-  // useEffect(() => {
-  //   console.log("contentsType", contentsType);
-  // }, [contentsType]);
-
-  // @공준혁 : 대댓글 or 댓글 삭제 버튼 클릭시 api 호출부 입니다.
 
   return (
     <div className={styles.commentItem}>
       <div className={styles.contentContainer}>
         <div className={styles.header}>
-          <img src={subComment.profileImage} className={styles.profileImage} alt="프로필 이미지" />
+          <img
+            src={subComment.profileImage}
+            className={styles.profileImage}
+            alt="프로필 이미지"
+          />
           <div className={styles.headerInfo}>
             <span className={styles.nickname}>{subComment.nickname}</span>
             <span className={styles.meta}>
@@ -63,9 +67,8 @@ const SubComment = ({ subComment, onReplyClick, onCommentDelete }: SubCommentPro
           <MoreModal
             iconSize={24}
             onDelete={() => {
-              console.log("deleteSubComment");
+              setContentsType("subComment");
               setIsOpen(true);
-              // setContentsType("subComment");
             }}
             isOpen={openModalId === `subComment-${subComment.id}`}
             onToggleModal={() => setOpenModalId(`subComment-${subComment.id}`)}
@@ -86,7 +89,12 @@ const SubComment = ({ subComment, onReplyClick, onCommentDelete }: SubCommentPro
         leftOnClick={() => setIsOpen(false)}
         leftText={"취소"}
         rightOnClick={() => {
-          onCommentDelete();
+          console.log(contentsType);
+          // if (contentsType === "subComment") {
+          //   deleteSubComment();
+          // } else {
+          //   onCommentDelete();
+          // }
           setIsOpen(false);
         }}
         rightText={"삭제할게요"}

--- a/src/common/component/SubComment/SubComment.tsx
+++ b/src/common/component/SubComment/SubComment.tsx
@@ -89,12 +89,11 @@ const SubComment = ({
         leftOnClick={() => setIsOpen(false)}
         leftText={"취소"}
         rightOnClick={() => {
-          console.log(contentsType);
-          // if (contentsType === "subComment") {
-          //   deleteSubComment();
-          // } else {
-          //   onCommentDelete();
-          // }
+          if (contentsType === "subComment") {
+            deleteSubComment();
+          } else {
+            onCommentDelete();
+          }
           setIsOpen(false);
         }}
         rightText={"삭제할게요"}

--- a/src/common/component/SubComment/SubCommentList.tsx
+++ b/src/common/component/SubComment/SubCommentList.tsx
@@ -6,7 +6,10 @@ interface SubCommentListProps {
   onCommentDelete: (id: number) => void;
 }
 
-const SubCommentList = ({ subComments, onCommentDelete }: SubCommentListProps) => {
+const SubCommentList = ({
+  subComments,
+  onCommentDelete,
+}: SubCommentListProps) => {
   return (
     <div>
       {subComments?.map((subComment) => (

--- a/src/common/component/SubComment/SubCommentList.tsx
+++ b/src/common/component/SubComment/SubCommentList.tsx
@@ -3,20 +3,20 @@ import { commentGetRequestSubCommentType } from "@api/domain/community/post";
 
 interface SubCommentListProps {
   subComments: commentGetRequestSubCommentType[];
-  onCommentDelete?: () => void;
+  onCommentDelete: (id: number) => void;
 }
 
-const SubCommentList = ({
-  subComments,
-  onCommentDelete,
-}: SubCommentListProps) => {
+const SubCommentList = ({ subComments, onCommentDelete }: SubCommentListProps) => {
   return (
     <div>
       {subComments?.map((subComment) => (
         <SubComment
           key={subComment.id}
           subComment={subComment}
-          onCommentDelete={onCommentDelete}
+          onCommentDelete={() => {
+            alert(subComment.id);
+            onCommentDelete(subComment.id as number);
+          }}
         />
       ))}
     </div>

--- a/src/common/component/SubComment/SubCommentList.tsx
+++ b/src/common/component/SubComment/SubCommentList.tsx
@@ -3,13 +3,21 @@ import { commentGetRequestSubCommentType } from "@api/domain/community/post";
 
 interface SubCommentListProps {
   subComments: commentGetRequestSubCommentType[];
+  onCommentDelete?: () => void;
 }
 
-const SubCommentList = ({ subComments }: SubCommentListProps) => {
+const SubCommentList = ({
+  subComments,
+  onCommentDelete,
+}: SubCommentListProps) => {
   return (
     <div>
       {subComments?.map((subComment) => (
-        <SubComment key={subComment.id} subComment={subComment} />
+        <SubComment
+          key={subComment.id}
+          subComment={subComment}
+          onCommentDelete={onCommentDelete}
+        />
       ))}
     </div>
   );

--- a/src/page/community/[postId]/Post.tsx
+++ b/src/page/community/[postId]/Post.tsx
@@ -10,13 +10,14 @@ import { TextField } from "@common/component/TextField";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import { formatTime } from "@shared/util/formatTime.ts";
 import useModalStore from "@store/moreModalStore.ts";
-
 import {
   useCommentsGet,
   useDeleteLike,
   useLikePost,
+  useDeleteComment,
   usePostGet,
 } from "@api/domain/community/post/hook";
+
 import { useNavigate, useParams } from "react-router-dom";
 import { PATH } from "@route/path.ts";
 import { getAccessToken } from "@api/index.ts";
@@ -156,7 +157,7 @@ const PostDetail = () => {
         </div>
         {postData.images?.map((image, index) => (
           <img
-            key={index}
+            key={`postImage-${index}`}
             src={image}
             alt="postImage"
             className={styles.image}
@@ -164,7 +165,7 @@ const PostDetail = () => {
         ))}
         <div className={styles.labelWrap}>
           {postData.tags?.map((tag, index) => (
-            <Chip label={tag} color={"blue"} />
+            <Chip key={`postTag-${index}`} label={tag} color={"blue"} />
           ))}
         </div>
         <div className={styles.subContents}>

--- a/src/page/community/[postId]/Post.tsx
+++ b/src/page/community/[postId]/Post.tsx
@@ -10,11 +10,17 @@ import { TextField } from "@common/component/TextField";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import { formatTime } from "@shared/util/formatTime.ts";
 import useModalStore from "@store/moreModalStore.ts";
-import { useCommentsGet, useDeleteLike, useLikePost, usePostGet } from "@api/domain/community/post/hook";
+import {
+  useCommentsGet,
+  useDeleteLike,
+  useLikePost,
+  usePostGet,
+} from "@api/domain/community/post/hook";
 
 import { useNavigate, useParams } from "react-router-dom";
 import { PATH } from "@route/path.ts";
 import { getAccessToken } from "@api/index.ts";
+import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet.tsx";
 
 const PostDetail = () => {
   const navigate = useNavigate();
@@ -25,14 +31,14 @@ const PostDetail = () => {
   const { mutate: likePost } = useLikePost(postId);
   const { mutate: likeDelete } = useDeleteLike(postId);
   const { data: commentsData } = useCommentsGet(Number(postId));
-  console.log(commentsData);
 
   const user = {
     accessToken:
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3MzcyMTAxMzgsImV4cCI6MTczNzgxNDkzOCwibWVtYmVySWQiOjF9.f6sCaL3PFg7yMb6J4PM1h30ADsiq_fbON31IXPguJ_Pb4otyJ_Qh-Z_JYRxC8a2SMzaa6jr68uLc6w0_tuag3A",
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3Mzc0ODQwNDAsImV4cCI6MTczODA4ODg0MCwibWVtYmVySWQiOjF9.NLB2jdV8n1pUCBoFxtLrTUKw8Lqi0CLyduNt5w4JEyJ0UL6tBuyahredqvfuB31D5E_saVb9OOVqe6WtClwufw",
   };
   localStorage.setItem("user", JSON.stringify(user));
 
+  const [isOpen, setOpen] = useState(false);
   const [isLiked, setIsLiked] = useState(postData?.isLiked);
   const [likeCount, setLikeCount] = useState(postData?.likeCounts);
   const [comment, setComment] = useState("");
@@ -55,6 +61,8 @@ const PostDetail = () => {
 
   const onDelete = () => {
     // TODO : 게시물 삭제하기 버튼 클릭 시 이벤트
+    // deletePost(postId);
+    setOpen(false);
   };
 
   useEffect(() => {
@@ -76,10 +84,12 @@ const PostDetail = () => {
       {
         onSuccess: (data) => {
           setIsLiked(false);
-          setLikeCount((prevState) => Number(prevState !== undefined ? prevState - 1 : 0));
+          setLikeCount((prevState) =>
+            Number(prevState !== undefined ? prevState - 1 : 0)
+          );
         },
         onError: (error) => {},
-      },
+      }
     );
   };
 
@@ -94,10 +104,12 @@ const PostDetail = () => {
       {
         onSuccess: (data) => {
           setIsLiked(true);
-          setLikeCount((prevState) => (prevState !== undefined ? prevState + 1 : 0));
+          setLikeCount((prevState) =>
+            prevState !== undefined ? prevState + 1 : 0
+          );
         },
         onError: (error) => {},
-      },
+      }
     );
   };
 
@@ -111,8 +123,10 @@ const PostDetail = () => {
         type={"noTitle"}
         rightBtn={
           <MoreModal
+            onDelete={() => {
+              setOpen(true);
+            }}
             iconSize={24}
-            onDelete={onDelete}
             isOpen={openModalId === `post-${postId}`}
             onToggleModal={() => setOpenModalId(`post-${postId}`)}
           />
@@ -127,11 +141,18 @@ const PostDetail = () => {
           disabled={true}
         />
         <div className={styles.top}>
-          {<img src={postData.profileImage} alt="userProfile" className={styles.profileImage} />}
+          {
+            <img
+              src={postData.profileImage}
+              alt="userProfile"
+              className={styles.profileImage}
+            />
+          }
           <div className={styles.info}>
             <div className={styles.infoName}>{postData.nickname}</div>
             <div className={styles.infoDetail}>
-              {postData.breed}·{postData.petAge}살 · {formatTime(postData.createdAt ?? "")}
+              {postData.breed}·{postData.petAge}살 ·{" "}
+              {formatTime(postData.createdAt ?? "")}
             </div>
           </div>
         </div>
@@ -140,7 +161,12 @@ const PostDetail = () => {
           <div className={styles.content}>{postData.content}</div>
         </div>
         {postData.images?.map((image, index) => (
-          <img key={`postImage-${index}`} src={image} alt="postImage" className={styles.image} />
+          <img
+            key={`postImage-${index}`}
+            src={image}
+            alt="postImage"
+            className={styles.image}
+          />
         ))}
         <div className={styles.labelWrap}>
           {postData.tags?.map((tag, index) => (
@@ -152,7 +178,11 @@ const PostDetail = () => {
             {isLiked ? (
               <IcLikeActive width={24} height={24} onClick={onLikePostClick} />
             ) : (
-              <IcLikeDisabled width={24} height={24} onClick={onLikeDeleteClick} />
+              <IcLikeDisabled
+                width={24}
+                height={24}
+                onClick={onLikeDeleteClick}
+              />
             )}
             <span>{likeCount}</span>
           </div>
@@ -161,7 +191,10 @@ const PostDetail = () => {
       <Divider size={"large"} />
       <div className={styles.container}>
         <div className={styles.commentTitle}>
-          댓글 <span className={styles.commentCount}>{postData.totalCommentCounts}</span>
+          댓글{" "}
+          <span className={styles.commentCount}>
+            {postData.totalCommentCounts}
+          </span>
         </div>
         <CommentList comments={{ comments: commentsData }} />
         <div className={styles.commentContainer}>
@@ -178,6 +211,17 @@ const PostDetail = () => {
           )}
         </div>
       </div>
+      <SimpleBottomSheet
+        isOpen={isOpen}
+        content={"댓글을 정말 삭제할까요?"}
+        handleClose={() => setOpen(false)}
+        leftOnClick={() => setOpen(false)}
+        leftText={"취소"}
+        rightOnClick={() => {
+          onDelete();
+        }}
+        rightText={"삭제할게요"}
+      />
     </>
   );
 };

--- a/src/page/community/[postId]/Post.tsx
+++ b/src/page/community/[postId]/Post.tsx
@@ -10,13 +10,7 @@ import { TextField } from "@common/component/TextField";
 import MoreModal from "@shared/component/MoreModal/MoreModal.tsx";
 import { formatTime } from "@shared/util/formatTime.ts";
 import useModalStore from "@store/moreModalStore.ts";
-import {
-  useCommentsGet,
-  useDeleteLike,
-  useLikePost,
-  useDeleteComment,
-  usePostGet,
-} from "@api/domain/community/post/hook";
+import { useCommentsGet, useDeleteLike, useLikePost, usePostGet } from "@api/domain/community/post/hook";
 
 import { useNavigate, useParams } from "react-router-dom";
 import { PATH } from "@route/path.ts";
@@ -31,6 +25,7 @@ const PostDetail = () => {
   const { mutate: likePost } = useLikePost(postId);
   const { mutate: likeDelete } = useDeleteLike(postId);
   const { data: commentsData } = useCommentsGet(Number(postId));
+  console.log(commentsData);
 
   const user = {
     accessToken:
@@ -81,12 +76,10 @@ const PostDetail = () => {
       {
         onSuccess: (data) => {
           setIsLiked(false);
-          setLikeCount((prevState) =>
-            Number(prevState !== undefined ? prevState - 1 : 0)
-          );
+          setLikeCount((prevState) => Number(prevState !== undefined ? prevState - 1 : 0));
         },
         onError: (error) => {},
-      }
+      },
     );
   };
 
@@ -101,12 +94,10 @@ const PostDetail = () => {
       {
         onSuccess: (data) => {
           setIsLiked(true);
-          setLikeCount((prevState) =>
-            prevState !== undefined ? prevState + 1 : 0
-          );
+          setLikeCount((prevState) => (prevState !== undefined ? prevState + 1 : 0));
         },
         onError: (error) => {},
-      }
+      },
     );
   };
 
@@ -136,18 +127,11 @@ const PostDetail = () => {
           disabled={true}
         />
         <div className={styles.top}>
-          {
-            <img
-              src={postData.profileImage}
-              alt="userProfile"
-              className={styles.profileImage}
-            />
-          }
+          {<img src={postData.profileImage} alt="userProfile" className={styles.profileImage} />}
           <div className={styles.info}>
             <div className={styles.infoName}>{postData.nickname}</div>
             <div className={styles.infoDetail}>
-              {postData.breed}·{postData.petAge}살 ·{" "}
-              {formatTime(postData.createdAt ?? "")}
+              {postData.breed}·{postData.petAge}살 · {formatTime(postData.createdAt ?? "")}
             </div>
           </div>
         </div>
@@ -156,12 +140,7 @@ const PostDetail = () => {
           <div className={styles.content}>{postData.content}</div>
         </div>
         {postData.images?.map((image, index) => (
-          <img
-            key={`postImage-${index}`}
-            src={image}
-            alt="postImage"
-            className={styles.image}
-          />
+          <img key={`postImage-${index}`} src={image} alt="postImage" className={styles.image} />
         ))}
         <div className={styles.labelWrap}>
           {postData.tags?.map((tag, index) => (
@@ -173,11 +152,7 @@ const PostDetail = () => {
             {isLiked ? (
               <IcLikeActive width={24} height={24} onClick={onLikePostClick} />
             ) : (
-              <IcLikeDisabled
-                width={24}
-                height={24}
-                onClick={onLikeDeleteClick}
-              />
+              <IcLikeDisabled width={24} height={24} onClick={onLikeDeleteClick} />
             )}
             <span>{likeCount}</span>
           </div>
@@ -186,10 +161,7 @@ const PostDetail = () => {
       <Divider size={"large"} />
       <div className={styles.container}>
         <div className={styles.commentTitle}>
-          댓글{" "}
-          <span className={styles.commentCount}>
-            {postData.totalCommentCounts}
-          </span>
+          댓글 <span className={styles.commentCount}>{postData.totalCommentCounts}</span>
         </div>
         <CommentList comments={{ comments: commentsData }} />
         <div className={styles.commentContainer}>

--- a/src/page/community/[postId]/Post.tsx
+++ b/src/page/community/[postId]/Post.tsx
@@ -14,6 +14,7 @@ import {
   useCommentsGet,
   useDeleteLike,
   useLikePost,
+  usePostDelete,
   usePostGet,
 } from "@api/domain/community/post/hook";
 
@@ -42,6 +43,7 @@ const PostDetail = () => {
   const [isLiked, setIsLiked] = useState(postData?.isLiked);
   const [likeCount, setLikeCount] = useState(postData?.likeCounts);
   const [comment, setComment] = useState("");
+  const { mutate: deletePost } = usePostDelete(Number(postId));
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
@@ -60,8 +62,7 @@ const PostDetail = () => {
   };
 
   const onDelete = () => {
-    // TODO : 게시물 삭제하기 버튼 클릭 시 이벤트
-    // deletePost(postId);
+    deletePost(Number(postId));
     setOpen(false);
   };
 

--- a/src/page/mypage/edit-pet/store/categoryFilter.ts
+++ b/src/page/mypage/edit-pet/store/categoryFilter.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand";
-import { CATEGORY_SYMPTOM, CATEGORY_DISEASE } from "@shared/component/FilterBottomSheet/CategoryContent/constant";
+import {
+  CATEGORY_SYMPTOM,
+  CATEGORY_DISEASE,
+} from "@shared/component/FilterBottomSheet/CategoryContent/constant";
 
 // todo: 추후 타입들 분리하기
 // 각 필터 항목의 기본 타입
@@ -36,6 +39,9 @@ interface CategoryFilterState {
   toggleOpen: () => void;
   setOpen: (state: boolean) => void;
 
+  contentsType: "comment" | "subComment";
+  setContentsType: (type: "comment" | "subComment") => void;
+
   category: CategoryType;
   setCategory: (category: CategoryType) => void;
 
@@ -57,13 +63,20 @@ interface CategoryFilterState {
 
   // 각 category에 해당하는 데이터 배열
   categoryData: CategoryData;
-  setCategoryData: (category: CategoryType, data: CategorySymptom | CategoryDisease) => void;
+  setCategoryData: (
+    category: CategoryType,
+    data: CategorySymptom | CategoryDisease
+  ) => void;
 }
 
 export const useCategoryFilterStore = create<CategoryFilterState>((set) => ({
   isOpen: false,
   toggleOpen: () => set((state) => ({ isOpen: !state.isOpen })),
   setOpen: (state) => set({ isOpen: state }),
+
+  // @공준혁 : 댓글과 대댓글을 구분하기 위한 contentsType
+  contentsType: "comment",
+  setContentsType: (contentsType) => set({ contentsType }),
 
   category: "disease",
   setCategory: (category) => set({ category }),
@@ -75,7 +88,9 @@ export const useCategoryFilterStore = create<CategoryFilterState>((set) => ({
       const currentList = state.selectedChips[category] || [];
       const alreadyExists = currentList.includes(id);
 
-      const updatedList = alreadyExists ? currentList.filter((chipId) => chipId !== id) : [...currentList, id];
+      const updatedList = alreadyExists
+        ? currentList.filter((chipId) => chipId !== id)
+        : [...currentList, id];
 
       return {
         selectedChips: {

--- a/src/shared/util/formatTime.ts
+++ b/src/shared/util/formatTime.ts
@@ -10,8 +10,6 @@ export const formatTime = (createdAt: string): string => {
   const diffDays = Math.floor(diffHours / 24);
   const diffYears = now.getFullYear() - createdDate.getFullYear();
 
-  console.log(diffSeconds, diffMinutes, diffHours, diffDays, diffYears);
-
   if (diffSeconds < 60) {
     return "방금 전";
   } else if (diffMinutes < 60) {


### PR DESCRIPTION
## 🔥 Related Issues

- close #135

## ✅ 작업 리스트

- [x] 게시물 삭제 api
- [x] 댓글 삭제 api
- [x] 대댓글 삭제 api 연동

## 🔧 작업 내용

댓글 api, 대댓글 api 연동 두개 하면서
simple Bottom Sheet 에서 문제가 많이 생겼는데요,
subcomment 인지 comment 인지 확인하는 전역 상태 만들어서 
그 값을 받아 수행하도록 해결하였으며,
comment id 를 따라가지 못하는 문제를 props 로 받으면서 해결했습니다.

```typescript

interface SubCommentListProps {
  subComments: commentGetRequestSubCommentType[];
  onCommentDelete: (id: number) => void;
}

const SubCommentList = ({
  subComments,
  onCommentDelete,
}: SubCommentListProps) => {

```

```typescript

interface SubCommentProps {
  subComment: commentGetRequestSubCommentType;
  onReplyClick?: (id: number | undefined) => void;
  onCommentDelete: () => void;
}

const SubComment = ({
  subComment,
  onReplyClick,
  onCommentDelete,
}: SubCommentProps) => {
```

고민을 많이 했는데요, Comment delete 하는 함수를 Subcomment 로 보내서 
모든 delete 하는 로직을 Subcomment 함수 내에서 핸들링 하도록 구현 했습니다. 




## 📣 리뷰어에게 어떠신가요?

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/bc54891d-0cae-4327-964b-0acf4e02b09f

