### PR TITLE
[Feat/#145] 닉네임 중복검사 api 연동

### DIFF
--- a/src/api/domain/onboarding/nicknameDuplicate/hook.ts
+++ b/src/api/domain/onboarding/nicknameDuplicate/hook.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getIsExist } from ".";
+
+export const MEMBERS_CHECK_QUERY_KEY = {
+  MEMBERS_CHECK_QUERY_KEY: (nickname: string) => ["check", nickname],
+};
+
+export const useCheckNicknameGet = (nickname: string) => {
+  return useQuery({
+    queryKey: MEMBERS_CHECK_QUERY_KEY.MEMBERS_CHECK_QUERY_KEY(nickname),
+    queryFn: () => {
+      return getIsExist(nickname);
+    },
+  });
+};

--- a/src/api/domain/onboarding/nicknameDuplicate/index.ts
+++ b/src/api/domain/onboarding/nicknameDuplicate/index.ts
@@ -1,0 +1,11 @@
+import { paths } from "@type/schema";
+import { get } from "@api/index";
+import { API_PATH } from "@api/constants/apiPath";
+
+export type isExistNicknameGetResponse = paths["/api/dev/members/check"]["get"]["responses"]["200"]["content"]["*/*"];
+
+export const getIsExist = async (nickname: string) => {
+  const { data } = await get<isExistNicknameGetResponse>(`${API_PATH.MEMBERS}/check`, { params: { nickname } });
+
+  return data.data;
+};

--- a/src/page/onboarding/index/component/nickname/Nickname.tsx
+++ b/src/page/onboarding/index/component/nickname/Nickname.tsx
@@ -8,6 +8,7 @@ import { validateNickname } from "@shared/util/validateNickname";
 import { Button } from "@common/component/Button";
 import { TextField } from "@common/component/TextField";
 import nicknameCoco from "@asset/image/nicknameCoco.png";
+import { useCheckNicknameGet } from "@api/domain/onboarding/nicknameDuplicate/hook";
 
 interface NicknamePros {
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -17,6 +18,9 @@ const Nickname = ({ setStep }: NicknamePros) => {
   // 상태 하나로 관리
   const [nickname, setNickname] = useState("");
 
+  // api 참 거짓을 반환
+  const { data: isExistNickname } = useCheckNicknameGet(nickname);
+
   // 닉네임 입력 처리
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setNickname(e.target.value);
@@ -24,6 +28,12 @@ const Nickname = ({ setStep }: NicknamePros) => {
 
   // 유효성 검사 결과
   const validationMessages = nickname ? validateNickname(nickname) : [];
+
+  // 중복 검사 메시지 추가
+  if (isExistNickname?.isExistNickname) {
+    validationMessages.push("이 닉네임은 누군가 사용 중이에요.");
+  }
+
   const isValid = nickname && validationMessages.length === 0;
 
   // TextField 상태

--- a/src/shared/util/validateNickname.ts
+++ b/src/shared/util/validateNickname.ts
@@ -1,13 +1,8 @@
 import { ERROR_MSG } from "@shared/constant/errorMsg";
-// 목데이터(추후 api연결시 삭제)
-const existingNicknames = ["0준혁", "딤민정C", "얄뭉", "알콜주도개발자"];
 
 export function validateNickname(nickname: string): string[] {
   const errors: string[] = [];
-  // 중복 닉네임
-  if (existingNicknames.includes(nickname)) {
-    errors.push(ERROR_MSG.nickname.duplicate);
-  }
+
   // 닉네임 길이
   if (nickname.length < 2 || nickname.length > 8) {
     errors.push(ERROR_MSG.nickname.length);


### PR DESCRIPTION
## 🔥 Related Issues

- close #145 

## ✅ 작업 리스트

- [x] 닉네임 중복조회 api 연동
- [x] 닉네임 중복시 오류 메시지 반영

## 🔧 작업 내용
닉네임 중복조회 api 연동했습니다.
닉네임 중복 에러 메시지 반영을 위해 작성해 두었던 중복검사 로직 삭제하고 에러메시지 반환할 수 있도록 연결해두었습니다.


## 📸 스크린샷 / GIF / Link
- 구현화면(현재 존재하는 닉네임명-> 키키)

https://github.com/user-attachments/assets/65bae180-7a71-4a15-a823-5c37e7027168

