### PR TITLE
[Feat/#158] 온보딩 ~ 반려동물 등록 반응형 레이아웃 구현 및 데이터 요청 시 깜빡임 문제 해결

### DIFF
--- a/src/api/domain/register-pet/petId/hook.ts
+++ b/src/api/domain/register-pet/petId/hook.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { getPetId } from "@api/domain/register-pet/petId/index";
 
 export const BREEDS_QUERY_KEY = {
@@ -9,5 +9,6 @@ export const usePetIdGet = (type: number) => {
   return useQuery({
     queryKey: BREEDS_QUERY_KEY.BREEDS_QUERY_KEY(type),
     queryFn: () => getPetId(type),
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/page/onboarding/index/component/nickname/Nickname.tsx
+++ b/src/page/onboarding/index/component/nickname/Nickname.tsx
@@ -67,6 +67,7 @@ const Nickname = ({ setStep }: NicknamePros) => {
             value={nickname}
             onChange={handleChange}
             placeholder="닉네임을 입력해주세요."
+            isDelete={false}
           />
           <div className={styles.errorLayout}>
             {validationMessages.map((message) => (

--- a/src/page/register-pet/index/common/ProgressBar/ProgressBar.css.ts
+++ b/src/page/register-pet/index/common/ProgressBar/ProgressBar.css.ts
@@ -6,6 +6,7 @@ import { createVar } from "@vanilla-extract/css";
 export const progressSizeVar = createVar();
 
 export const barStyle = style({
+  maxWidth: "76.8rem",
   overflow: "hidden",
   position: "fixed",
   top: "4rem",

--- a/src/page/register-pet/index/common/ProgressBar/ProgressBar.css.ts
+++ b/src/page/register-pet/index/common/ProgressBar/ProgressBar.css.ts
@@ -6,7 +6,7 @@ import { createVar } from "@vanilla-extract/css";
 export const progressSizeVar = createVar();
 
 export const barStyle = style({
-  maxWidth: "76.8rem",
+  maxWidth: "72.8rem",
   overflow: "hidden",
   position: "fixed",
   top: "4rem",

--- a/src/page/register-pet/index/component/petHealth/disease/Step1.css.ts
+++ b/src/page/register-pet/index/component/petHealth/disease/Step1.css.ts
@@ -15,7 +15,6 @@ export const contentWrapper = style({
   alignItems: "center",
   gap: "0.8rem 2rem",
   flexWrap: "wrap",
-  width: "28.4rem",
   margin: "0 4.55rem",
 });
 

--- a/src/page/register-pet/index/component/petHealth/disease/Step1.tsx
+++ b/src/page/register-pet/index/component/petHealth/disease/Step1.tsx
@@ -45,7 +45,7 @@ const Step1 = ({ selectedIds, data, onBodyPartSelection }: CombinedStepProps) =>
               }}
               type="button"
             >
-              <img src={body.image} width={56} height={56} alt="body-img" />
+              <img src={body.image} height={56} alt="body-img" />
             </button>
             <p>{body.name}</p>
           </div>

--- a/src/page/register-pet/index/component/petHealth/disease/Step2.css.ts
+++ b/src/page/register-pet/index/component/petHealth/disease/Step2.css.ts
@@ -23,7 +23,7 @@ export const chipLayout = style({
   display: "flex",
   flexWrap: "wrap",
   gap: "1.2rem 0.4rem",
-  width: "33.5rem",
+  maxWidth: "76.8rem",
 });
 
 export const selectedBody = style([

--- a/src/page/register-pet/index/component/petHealth/symptom/SymStep1.tsx
+++ b/src/page/register-pet/index/component/petHealth/symptom/SymStep1.tsx
@@ -48,7 +48,7 @@ const SymStep1 = ({ data, selectedIds, onBodyPartSelection }: CombinedSymStepPro
               }}
               type="button"
             >
-              <img src={body.image} width={56} height={56} alt="body-img" />
+              <img src={body.image} height={56} alt="body-img" />
             </button>
             <p>{body.name}</p>
           </div>

--- a/src/page/register-pet/index/component/petId/PetId.tsx
+++ b/src/page/register-pet/index/component/petId/PetId.tsx
@@ -5,10 +5,10 @@ import Title from "@page/onboarding/index/common/title/Title";
 import Docs from "../../../../onboarding/index/common/docs/Docs";
 import { TextField } from "@common/component/TextField";
 import { Button } from "@common/component/Button";
-// import { ANIMAL } from "@page/registerPet/index/common/dropDown/constant";
 import DropDown from "@page/register-pet/index/common/dropDown/DropDown";
 import { PetData } from "@page/register-pet/index/RegisterPet";
 import { usePetIdGet } from "@api/domain/register-pet/petId/hook";
+
 // breedItem 타입 정의
 interface BreedItem {
   id: number;
@@ -20,6 +20,7 @@ interface PetIdProps {
   updatePetData: (field: keyof PetData, value: PetData[keyof PetData]) => void;
   petData: PetData;
 }
+
 const PetId = ({ setStep, updatePetData, petData }: PetIdProps) => {
   const [input, setInput] = useState("");
   const [filteredItems, setFilteredItems] = useState<BreedItem[]>([]);
@@ -28,15 +29,16 @@ const PetId = ({ setStep, updatePetData, petData }: PetIdProps) => {
   const { data } = usePetIdGet(Number(petData.breedId));
 
   if (!data) return null;
+
   const getAllItems = (): BreedItem[] => {
     const breeds = data.data?.breeds || []; // undefined이면 빈 배열 반환
     return breeds.filter((breed): breed is BreedItem => breed.id !== undefined && breed.name !== undefined);
   };
+
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/\s+/g, ""); // 모든 공백 제거
     setInput(value);
 
-    const allItems = getAllItems();
     if (value.length > 0) {
       // 입력값과 품종명에서 모든 공백 제거 후 비교
       const filtered = allItems.filter((item) => item.name.replace(/\s+/g, "").includes(value));
@@ -45,6 +47,7 @@ const PetId = ({ setStep, updatePetData, petData }: PetIdProps) => {
       setFilteredItems(allItems); // 입력값이 없으면 전체 품종 목록
     }
   };
+
   const handleDropDownClick = (value: string) => {
     const trimmedValue = value.replace(/\s+/g, ""); // 선택된 값에서 모든 공백 제거
     setInput(trimmedValue);
@@ -54,7 +57,14 @@ const PetId = ({ setStep, updatePetData, petData }: PetIdProps) => {
     }
   };
 
-  const isDropDownOpen = input.length > 0 && filteredItems.length > 0;
+  // 드롭다운 열림 여부 결정
+  const allItems = getAllItems();
+  const isDropDownOpen =
+    input.length > 0 &&
+    filteredItems.length > 0 &&
+    JSON.stringify(filteredItems) !== JSON.stringify(allItems) && // 필터된 품종 목록과 전체 목록이 다르면
+    !filteredItems.some((breed) => breed.name.replace(/\s+/g, "") === input); // 입력값이 선택된 품종과 동일하지 않으면
+
   const isInputValid = filteredItems.some((breed) => breed.name.replace(/\s+/g, "") === input);
 
   const handleGoBack = () => {

--- a/src/page/register-pet/index/component/petName/PetName.css.ts
+++ b/src/page/register-pet/index/component/petName/PetName.css.ts
@@ -4,7 +4,8 @@ export const layout = style({
   position: "absolute",
   top: "8rem",
 
-  minWidth: "37.1rem",
+  width: "100%",
+  maxWidth: "76.8rem",
 
   display: "flex",
   flexDirection: "column",

--- a/src/page/register-pet/index/component/petName/PetName.tsx
+++ b/src/page/register-pet/index/component/petName/PetName.tsx
@@ -55,6 +55,7 @@ const PetName = ({ setStep, updatePetData }: PetNameProps) => {
             value={petName}
             onChange={handleChange}
             placeholder="반려동물의 이름을 입력해주세요."
+            isDelete={false}
           />
           <div className={styles.errorLayout}>
             {validationMessages.map((message) => (


### PR DESCRIPTION
## 🔥 Related Issues

- close #158 

## ✅ 작업 리스트

- [x] 레이아웃 안맞는 부분 반영
- [x] 반응형에 맞게 자잘한 레이아웃 수정
- [x] 드롭다운 클릭 시 깜빡이는 문제 해결

## 🔧 작업 내용
레이아웃이 자잘하게 안맞는게 있어서 반영 완료했습니다.

반응형으로 해보니까 몇 개가 안맞더라고요.. 수정 완료했습니다.

드롭 다운 클릭 시 깜!빡 하는 문제가 있었습니다. 
리액트 쿼리의 옵션으로, 해당 옵션을 활용함으로써 새로운 쿼리키로 재패치하기 전까지 이전 값을 유지할 데이터를 만들어주는

`placeholderData: keepPreviousData,`

로 해결했습니다. 


## 📸 스크린샷 / GIF / Link
- 스무스하게 드롭다운 내용 텍스트필드 반영

https://github.com/user-attachments/assets/868c9afe-4233-4237-befc-71ad7c878d5a

