### PR TITLE
[Refactor/#441] bottomSheet 구조 개선, useEffect 최소화  - 장기적 todo

### DIFF
--- a/src/api/domain/mypage/edit-pet/hook.ts
+++ b/src/api/domain/mypage/edit-pet/hook.ts
@@ -53,19 +53,25 @@ export const useGetBodies = (petProblem: "DISEASE" | "SYMPTOM") => {
   });
 };
 
-export const useGetSymptoms = (bodyIds: number[]) => {
+export const useGetSymptoms = (bodyIds: number[] | undefined) => {
+  const _bodyIds= bodyIds ? bodyIds : []
+  const _enabled= _bodyIds.length > 0
   return useQuery({
-    queryKey: SYMPTOMS_QUERY_KEY.SYMPTOMS(bodyIds),
-    queryFn: () => getSymptoms(bodyIds),
+    queryKey: SYMPTOMS_QUERY_KEY.SYMPTOMS(_bodyIds),
+    queryFn: () => getSymptoms(_bodyIds),
     staleTime: 1000 * 60 * 10,
+    enabled: _enabled
   });
 };
 
-export const useGetDisease = (bodyIds: number[]) => {
+export const useGetDisease = (bodyIds: number[] | undefined) => {
+  const _bodyIds= bodyIds ? bodyIds : []
+  const _enabled= _bodyIds.length > 0
   return useQuery({
-    queryKey: DISEASE_QUERY_KEY.DISEASE(bodyIds),
-    queryFn: () => getDisease(bodyIds),
+    queryKey: DISEASE_QUERY_KEY.DISEASE(_bodyIds),
+    queryFn: () => getDisease(_bodyIds),
     staleTime: 1000 * 60 * 10,
+    enabled: _enabled
   });
 };
 

--- a/src/app/mypage/edit-pet/page.tsx
+++ b/src/app/mypage/edit-pet/page.tsx
@@ -52,8 +52,6 @@ const Page = () => {
   const [validationMessages, setValidationMessages] = useState<string[]>([]);
   const [isValid, setIsVaild] = useState(false);
   const [petAge, setPetAge] = useState("");
-  const [bodyDiseaseIds, setBodyDiseaseIds] = useState<number[]>([]); //api 요청으로 받아온 body id들을 저장해두었다가, 다시 요청에 사용
-  const [bodySymptomsIds, setBodySymptomsIds] = useState<number[]>([]); //api 요청으로 받아온 body id들을 저장해두었다가, 다시 요청에 사용
 
   const member = useMypageMemberInfo((s) => s.member);
   const setMemberInfo = useMypageMemberInfo((s) => s.setMemberInfo);
@@ -89,11 +87,14 @@ const Page = () => {
 
   const { data: animal } = useGetAnimal();
   const { data: breed } = useGetBreed((animalChips.animalId as number) || 1);
+
   const { data: diseaseBodies } = useGetBodies("DISEASE");
   const { data: symptomBodies } = useGetBodies("SYMPTOM");
-
-  const { data: symptoms } = useGetSymptoms(bodySymptomsIds);
+  const bodyDiseaseIds = diseaseBodies?.bodies?.map((item) => item.id as number);
+  const bodySymptomsIds = symptomBodies?.bodies?.map((item) => item.id as number);
   const { data: disease } = useGetDisease(bodyDiseaseIds);
+  const { data: symptoms } = useGetSymptoms(bodySymptomsIds);
+  
   const { data: petInfo } = useGetPetInfo();
   const { mutate: patchPetInfo } = usePatchPetInfo();
 
@@ -103,17 +104,6 @@ const Page = () => {
       setMemberInfo(memberData);
     }
   }, [memberData, setMemberInfo]);
-
-  useEffect(() => {
-    if (diseaseBodies?.bodies && symptomBodies?.bodies) {
-      const diseaseIdArr = diseaseBodies.bodies.map((item) => item.id as number);
-      const symptomIdArr = symptomBodies.bodies.map((item) => item.id as number);
-      if (diseaseIdArr.length && symptomIdArr.length) {
-        setBodyDiseaseIds(diseaseIdArr);
-        setBodySymptomsIds(symptomIdArr);
-      }
-    }
-  }, [diseaseBodies, symptomBodies]);
 
   useEffect(() => {
     // animalId가 변경되었을 때만 breedId를 초기화


### PR DESCRIPTION
## 🔥 Related Issues

- close #441 

## ✅ 작업 리스트

- [ ] 체크리스트
- [ ] 체크리스트

## 🔧 작업 내용
useEffect를 줄이기 위한 작업이었으나, 진행하려고 설계를 확인하다보니 바텀시트의 구조도 변경되어야 했어요.
따라서 바텀시트의 구조를 개선하고, useEffect를 최대한 줄이는 작업이에요.

## 📣 리뷰어에게

## 📸 스크린샷 / GIF / Link
