### PR TITLE
[Feat] 로그인 과정에서 RedirectUrl 같이 넘겨주도록 수정

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -30,6 +30,7 @@ function AuthRedirectContent() {
           body: JSON.stringify({
             platform: "KAKAO",
             code: code,
+            redirectUri: process.env.NEXT_PUBLIC_REDIRECT_URI,
           }),
         });
 


### PR DESCRIPTION
## ✅ 작업 리스트

- [x] getAccessToken Payload에 redirectUrl 같이 넘기도록 수정

## 🔧 작업 내용
OAuth 로그인에는 항상 redirectUrl를 넘기도록 설정되어있는데, 이를 하나로 고정해두면 local, dev, main 환경에서 일관되게 로그인 작업을 수행할 수 없어요. (서버에서는 redirectUrl을 하나의 값으로 설정해두고, 그 값으로 카카오에서 코드를 받아오기 때문이에요)

redirectUrl 자체는 노출되어도 보안상 위협될 부분은 없으므로, 이를 payload로 넘겨서 서버 측에서 redirectUrl를 설정하도록 만들어요.
(clientId만 노출되지 않도록 조심하면 돼요)

## 📣 리뷰어에게
간단한 작업이라 빠르게 작업하고 머지해둡니다 ~!

