### PR TITLE
[QA] 마이페이지 텍스트 수정, Tab 컴포넌트 수정

### DIFF
--- a/src/app/mypage/_component/TabsSection/TabsSection.tsx
+++ b/src/app/mypage/_component/TabsSection/TabsSection.tsx
@@ -9,16 +9,32 @@ interface TabsSectionProps {
   onTabClick: (tab: ActiveTabType) => void;
 }
 
-const TabsSection = ({ activeTab, isActiveTab, onTabClick }: TabsSectionProps) => {
+const TabsSection = ({
+  activeTab,
+  isActiveTab,
+  onTabClick,
+}: TabsSectionProps) => {
   return (
     <div className={styles.contentHeaderWrapper}>
-      <Tab active={isActiveTab("review")} width={"100%"} onClick={() => onTabClick("review")}>
+      <Tab
+        active={isActiveTab("review")}
+        width={"100%"}
+        onClick={() => onTabClick("review")}
+      >
         나의 병원 후기
       </Tab>
-      <Tab active={isActiveTab("post")} width={"100%"} onClick={() => onTabClick("post")}>
+      <Tab
+        active={isActiveTab("post")}
+        width={"100%"}
+        onClick={() => onTabClick("post")}
+      >
         나의 게시글
       </Tab>
-      <Tab active={isActiveTab("comment")} width={"100%"} onClick={() => onTabClick("comment")}>
+      <Tab
+        active={isActiveTab("comment")}
+        width={"100%"}
+        onClick={() => onTabClick("comment")}
+      >
         나의 댓글
       </Tab>
     </div>

--- a/src/app/mypage/_component/TabsSection/TabsSection.tsx
+++ b/src/app/mypage/_component/TabsSection/TabsSection.tsx
@@ -21,21 +21,21 @@ const TabsSection = ({
         width={"100%"}
         onClick={() => onTabClick("review")}
       >
-        나의 병원 후기
+        병원 후기
       </Tab>
       <Tab
         active={isActiveTab("post")}
         width={"100%"}
         onClick={() => onTabClick("post")}
       >
-        나의 게시글
+        게시글
       </Tab>
       <Tab
         active={isActiveTab("comment")}
         width={"100%"}
         onClick={() => onTabClick("comment")}
       >
-        나의 댓글
+        댓글
       </Tab>
     </div>
   );

--- a/src/common/component/Tab/Tab.css.ts
+++ b/src/common/component/Tab/Tab.css.ts
@@ -10,19 +10,27 @@ export const tab = style({
   gap: "0.4rem",
 });
 
-export const tabContent = style([
-  font.body01,
-  {
-    display: "flex",
-    height: "3.6rem",
-    padding: "0.8rem 1.6rem",
-    justifyContent: "center",
-    alignItems: "center",
-    alignSelf: "stretch",
-    whiteSpace: "nowrap",
-    color: semanticColor.text.normal,
+export const tabContent = recipe({
+  base: [
+    font.body01,
+    {
+      display: "flex",
+      height: "3.6rem",
+      padding: "0.8rem 1.6rem",
+      justifyContent: "center",
+      alignItems: "center",
+      alignSelf: "stretch",
+      whiteSpace: "nowrap",
+      color: semanticColor.text.normal,
+    },
+  ],
+  variants: {
+    active: {
+      true: { color: semanticColor.text.normal },
+      false: { color: semanticColor.disable.text },
+    },
   },
-]);
+});
 
 export const tabBar = recipe({
   base: {

--- a/src/common/component/Tab/Tab.tsx
+++ b/src/common/component/Tab/Tab.tsx
@@ -8,10 +8,16 @@ interface TabPropTypes {
   onClick?: () => void;
 }
 
-const Tab = ({ children, width, onClick, active = false, variant = "good" }: TabPropTypes) => {
+const Tab = ({
+  children,
+  width,
+  onClick,
+  active = false,
+  variant = "good",
+}: TabPropTypes) => {
   return (
     <div style={{ width: width }} className={styles.tab} onClick={onClick}>
-      <div className={styles.tabContent}>{children}</div>
+      <div className={styles.tabContent({ active: active })}>{children}</div>
       <div className={styles.tabBar({ active: active, variant })} />
     </div>
   );


### PR DESCRIPTION
## 🔥 Related Issues

- close #521

## ✅ 작업 리스트

- [x] fix: tab 비활성화 style 추가
- [x] 마이페이지 Tab 텍스트 변경 

## 🔧 작업 내용

### tab 비활성화 style 추가

<img width="398" height="528" alt="스크린샷 2026-06-11 02 00 10" src="https://github.com/user-attachments/assets/04b1818e-ed1f-478b-8124-06dcfabb2d23" />

다른 곳에서도 다 비활성화 버튼이 회색이어야 하는데, 지금 보니까 다 블랙인 오류가 있어 수정했어요. 

### 마이페이지 Tab 텍스트 변경 

마이페이지 버튼에 있는 Tab 의 텍스트 변경 QA 적용했어요. 

나의 병원후기 → 병원 후기
나의 게시글 → 게시글
나의 댓글 → 댓글

<img width="766" height="252" alt="스크린샷 2026-06-11 02 04 37" src="https://github.com/user-attachments/assets/1821d28f-4cb5-44b2-abdc-f0db2d2bb748" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 탭의 활성/비활성 상태에 따라 텍스트 색상이 동적으로 변경되도록 개선
  
* **UI 변경**
  * 탭 레이블 텍스트 업데이트 ("나의 병원 후기" → "병원 후기" 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->