### PR TITLE
[QA] writable category api 연동, NEW 필터 UI 적용

### DIFF
--- a/src/api/constants/apiPath.ts
+++ b/src/api/constants/apiPath.ts
@@ -27,6 +27,7 @@ export const API_PATH = {
   POST_FILTERS: "posts/filters",
   POST_POPULAR: "posts/popular",
   POST_CATEGORIES: "posts/categories",
+  POST_CATEGORIES_WRITABLE: "posts/categories/writable",
 
   TEST_HEALTH_CHECK: "test/health-check",
   TEST_TOKEN_CHECK: "test/token-check",

--- a/src/api/domain/review/write/hook.ts
+++ b/src/api/domain/review/write/hook.ts
@@ -1,11 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
-import { getPurpose } from "@api/domain/review/write";
+import { getPurpose, getWritableCategory } from "@api/domain/review/write";
 
 export const usePurposeGet = () => {
   return useQuery({
     queryKey: ["purpose"],
     queryFn: () => {
       return getPurpose();
+    },
+  });
+};
+
+export const useGetWritableCategoryData = () => {
+  return useQuery({
+    queryKey: ["dropdownDataByCategory"],
+    queryFn: () => {
+      return getWritableCategory();
     },
   });
 };

--- a/src/api/domain/review/write/index.ts
+++ b/src/api/domain/review/write/index.ts
@@ -2,9 +2,24 @@ import { paths } from "@type/schema";
 import { API_PATH } from "@api/constants/apiPath";
 import { get } from "@api/index";
 
-export type purposeGetResponse = paths["/api/dev/hospitals/purposes"]["get"]["responses"]["200"]["content"]["*/*"];
+export type purposeGetResponse =
+  paths["/api/dev/hospitals/purposes"]["get"]["responses"]["200"]["content"]["*/*"];
 
 export const getPurpose = async () => {
-  const { data } = await get<purposeGetResponse>(API_PATH.HOSPITALS_PURPOSE, {});
+  const { data } = await get<purposeGetResponse>(
+    API_PATH.HOSPITALS_PURPOSE,
+    {},
+  );
+  return data.data;
+};
+
+export type writableCategoryDataResponse =
+  paths["/api/dev/posts/categories/writable"]["get"]["responses"]["200"]["content"]["*/*"];
+
+export const getWritableCategory = async () => {
+  const { data } = await get<writableCategoryDataResponse>(
+    API_PATH.POST_CATEGORIES_WRITABLE,
+    {},
+  );
   return data.data;
 };

--- a/src/app/community/_component/DropDown/DropDown.tsx
+++ b/src/app/community/_component/DropDown/DropDown.tsx
@@ -1,19 +1,21 @@
 import {container, itemStyle} from "./DropDown.css.ts";
 import React from "react";
 
-type DropDownType = {
+export interface DropDownItem {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  english?: string;
+};
+
+interface DropDownProps {
   isOpen: boolean;
-  items: Array<{
-    icon: React.ReactNode;
-    value: number;
-    label: string;
-    english: string;
-  }>;
+  items: Array<DropDownItem>;
   onClickItem: (target: string, value: string | number) => void;
   toggleDropDown: () => void;
 };
 
-const DropDown = ({ isOpen, items, onClickItem, toggleDropDown }: DropDownType) => {
+const DropDown = ({ isOpen, items, onClickItem, toggleDropDown }: DropDownProps) => {
   if (!isOpen) {
     return;
   }

--- a/src/app/community/_utills/formatWritableCategories.tsx
+++ b/src/app/community/_utills/formatWritableCategories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { components } from "@type/schema";
+
+type PostCategory = components["schemas"]["PostCategoryResponse"];
+
+export type DropDownItem = {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  english: string;
+};
+
+const CATEGORY_NAME_TO_ENGLISH: Record<string, string> = {
+  "증상·질병": "symptom",
+  병원고민: "hospital",
+  "일상·치유": "healing",
+  코코스매거진: "magazine",
+};
+
+export const getCategoryEnglishByName = (name: string) => {
+  return CATEGORY_NAME_TO_ENGLISH[name] ?? "";
+};
+
+export const formatCategoriesToDropDownItems = (
+  categories: PostCategory[] = [],
+): DropDownItem[] => {
+  return categories
+    .filter((category) => category.id != null && category.name)
+    .map((category) => ({
+      icon: category.image ? (
+        <img src={category.image} alt={category.name} width={20} height={20} />
+      ) : null,
+      label: category.name!,
+      value: category.id!,
+      english: getCategoryEnglishByName(category.name!),
+    }));
+};

--- a/src/app/community/_utills/formatWritableCategories.tsx
+++ b/src/app/community/_utills/formatWritableCategories.tsx
@@ -12,13 +12,9 @@ export type DropDownItem = {
 
 const CATEGORY_NAME_TO_ENGLISH: Record<string, string> = {
   "증상·질병": "symptom",
-  병원고민: "hospital",
+  "병원고민": "hospital",
   "일상·치유": "healing",
-  코코스매거진: "magazine",
-};
-
-export const getCategoryEnglishByName = (name: string) => {
-  return CATEGORY_NAME_TO_ENGLISH[name] ?? "";
+  "코코스매거진": "magazine",
 };
 
 export const formatCategoriesToDropDownItems = (
@@ -32,6 +28,6 @@ export const formatCategoriesToDropDownItems = (
       ) : null,
       label: category.name!,
       value: category.id!,
-      english: getCategoryEnglishByName(category.name!),
+      english: CATEGORY_NAME_TO_ENGLISH[category.name!] ?? "",
     }));
 };

--- a/src/app/community/_utills/formatWritableCategories.tsx
+++ b/src/app/community/_utills/formatWritableCategories.tsx
@@ -1,25 +1,11 @@
 import React from "react";
 import { components } from "@type/schema";
-
-type PostCategory = components["schemas"]["PostCategoryResponse"];
-
-export type DropDownItem = {
-  icon: React.ReactNode;
-  label: string;
-  value: number;
-  english: string;
-};
-
-const CATEGORY_NAME_TO_ENGLISH: Record<string, string> = {
-  "증상·질병": "symptom",
-  "병원고민": "hospital",
-  "일상·치유": "healing",
-  "코코스매거진": "magazine",
-};
+import { DropDownItem } from "../_component/DropDown/DropDown";
 
 export const formatCategoriesToDropDownItems = (
-  categories: PostCategory[] = [],
+  response: components["schemas"]["PostCategoriesResponse"] | undefined,
 ): DropDownItem[] => {
+  const categories = response?.categories ?? [];
   return categories
     .filter((category) => category.id != null && category.name)
     .map((category) => ({
@@ -28,6 +14,5 @@ export const formatCategoriesToDropDownItems = (
       ) : null,
       label: category.name!,
       value: category.id!,
-      english: CATEGORY_NAME_TO_ENGLISH[category.name!] ?? "",
     }));
 };

--- a/src/app/community/_utills/formatWritableCategories.tsx
+++ b/src/app/community/_utills/formatWritableCategories.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { components } from "@type/schema";
 import { DropDownItem } from "../_component/DropDown/DropDown";
 
+type PostCategoryType = components["schemas"]["PostCategoriesResponse"];
+
 export const formatCategoriesToDropDownItems = (
-  response: components["schemas"]["PostCategoriesResponse"] | undefined,
+  response: PostCategoryType | undefined,
 ): DropDownItem[] => {
   const categories = response?.categories ?? [];
   return categories
@@ -12,7 +14,7 @@ export const formatCategoriesToDropDownItems = (
       icon: category.image ? (
         <img src={category.image} alt={category.name} width={20} height={20} />
       ) : null,
-      label: category.name!,
-      value: category.id!,
+      label: category.name ?? "",
+      value: category.id ?? 0,
     }));
 };

--- a/src/app/community/_utills/handleCategoryItem.tsx
+++ b/src/app/community/_utills/handleCategoryItem.tsx
@@ -1,19 +1,30 @@
 import { IcDeleteBlack } from "@asset/svg";
 import { DropDownItems } from "../_constant/writeConfig.tsx";
+import { DropDownItem } from "./formatWritableCategories.tsx";
 
-export const getDropdownIdtoIcon = (categoryId: number | undefined) => {
+const emptyIconSpace = (
+  <span style={{ display: "inline-block", width: 20, height: 20 }} />
+);
+
+export const getDropdownIdtoIcon = (
+  categoryId: number | undefined,
+  items: DropDownItem[] = [],
+) => {
   if (!categoryId) {
-    return <IcDeleteBlack width={24} />;
+    return emptyIconSpace;
   }
 
-  const selectedItem = DropDownItems.find((item) => categoryId === item.value);
-  if (!selectedItem) return <IcDeleteBlack width={24} />;
+  const selectedItem = items.find((item) => categoryId === item.value);
+  if (!selectedItem?.icon) return <IcDeleteBlack width={24} />;
 
   return selectedItem.icon;
 };
 
-export const getDropdownIdtoValue = (categoryId: number | undefined) => {
-  const selectedItem = DropDownItems.find((item) => categoryId === item.value);
+export const getDropdownIdtoValue = (
+  categoryId: number | undefined,
+  items: DropDownItem[] = [],
+) => {
+  const selectedItem = items.find((item) => categoryId === item.value);
   return selectedItem ? selectedItem.label : "";
 };
 

--- a/src/app/community/_utills/handleCategoryItem.tsx
+++ b/src/app/community/_utills/handleCategoryItem.tsx
@@ -1,6 +1,6 @@
 import { IcDeleteBlack } from "@asset/svg";
 import { DropDownItems } from "../_constant/writeConfig.tsx";
-import { DropDownItem } from "./formatWritableCategories.tsx";
+import { DropDownItem } from "@app/community/_component/DropDown/DropDown.tsx";
 
 const emptyIconSpace = (
   <span style={{ display: "inline-block", width: 20, height: 20 }} />
@@ -8,7 +8,7 @@ const emptyIconSpace = (
 
 export const getDropdownIdtoIcon = (
   categoryId: number | undefined,
-  items: DropDownItem[] = [],
+  items: DropDownItem[],
 ) => {
   if (!categoryId) {
     return emptyIconSpace;
@@ -22,7 +22,7 @@ export const getDropdownIdtoIcon = (
 
 export const getDropdownIdtoValue = (
   categoryId: number | undefined,
-  items: DropDownItem[] = [],
+  items: DropDownItem[],
 ) => {
   const selectedItem = items.find((item) => categoryId === item.value);
   return selectedItem ? selectedItem.label : "";

--- a/src/app/community/category/Category.css.ts
+++ b/src/app/community/category/Category.css.ts
@@ -1,5 +1,5 @@
-import {style} from "@vanilla-extract/css";
-import {color, font} from "@style/styles.css";
+import { style } from "@vanilla-extract/css";
+import { color, font } from "@style/styles.css";
 
 export const categoryContainer = style({
   width: "100%",
@@ -7,6 +7,15 @@ export const categoryContainer = style({
 
 export const postsContainer = style({
   padding: "1.6rem 2rem 2rem 2rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.6rem",
+  alignItems: "flex-start",
+});
+
+export const postsContent = style({
+  width: "100%",
+
   display: "flex",
   flexDirection: "column",
   gap: "1.6rem",

--- a/src/app/community/category/page.tsx
+++ b/src/app/community/category/page.tsx
@@ -4,25 +4,35 @@ import { useRouter, useSearchParams } from "next/navigation";
 import * as styles from "./Category.css";
 import Content from "@common/component/Content/Content";
 import HeaderNav from "@common/component/HeaderNav/HeaderNav";
-import { Icfilter, Icfilteron, IcLeftarrow, IcSearch } from "@asset/svg";
+import { IcLeftarrow, IcSearch } from "@asset/svg";
 import FloatingBtn from "@common/component/FloatingBtn/Floating";
 import FilterBottomSheet from "@shared/component/FilterBottomSheet/FilterBottomSheet";
-import { useFilterStore } from "@store/filter";
+import { SelectedChips, useFilterStore } from "@store/filter";
 import { PATH } from "@route/path";
 import { formatTime } from "@shared/util/formatTime";
 import { usePostPostFilters } from "@api/domain/community/search/hook";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { components } from "@type/schema";
 import { postPostFiltersRequest } from "@api/domain/community/search";
-import { useGetBodies, useGetDisease, useGetSymptoms } from "@api/domain/mypage/edit-pet/hook";
+import {
+  useGetAnimal,
+  useGetBodies,
+  useGetDisease,
+  useGetSymptoms,
+} from "@api/domain/mypage/edit-pet/hook";
 import dynamic from "next/dynamic";
 import NoData from "@shared/component/NoData/NoData.tsx";
 import { useAuth } from "@providers/AuthProvider";
 import { useIsPetRegistered } from "@common/hook/useIsPetRegistered";
 import { Modal } from "@common/component/Modal/Modal";
 import LoginModal from "@common/component/LoginModal/LoginModal.tsx";
+import { SearchFilter } from "../_component/SearchFilter/SearchFilter";
+import { If } from "@shared/component/If/if";
 
-const Loading = dynamic(() => import("../../../common/component/Loading/Loading.tsx"), { ssr: false });
+const Loading = dynamic(
+  () => import("../../../common/component/Loading/Loading.tsx"),
+  { ssr: false },
+);
 
 export const validTypes = ["symptom", "hospital", "healing", "magazine"];
 const categoryMapping: { [key: string]: string } = {
@@ -42,13 +52,14 @@ const CategoryContent = () => {
   const searchParams = useSearchParams();
   const type = searchParams?.get("type");
   const typeId = searchParams?.get("id");
-  const [posts, setPosts] = useState<components["schemas"]["PostResponse"][]>([]);
+  const [posts, setPosts] = useState<components["schemas"]["PostResponse"][]>(
+    [],
+  );
   const { mutate: fetchPosts, isPending } = usePostPostFilters();
   const router = useRouter();
 
   // 필터 관련 상태와 hooks
-  const { isOpen, setOpen, category, setCategory, setCategoryData, selectedChips, toggleChips, categoryData } =
-    useFilterStore();
+  const { isOpen, setCategoryData, selectedChips } = useFilterStore();
   const { clearAllChips } = useFilterStore();
 
   const [bodyDiseaseIds, setBodyDiseaseIds] = useState<number[]>([]);
@@ -57,6 +68,7 @@ const CategoryContent = () => {
   const { data: symptomBodies } = useGetBodies("SYMPTOM");
   const { data: symptoms } = useGetSymptoms(bodySymptomsIds);
   const { data: disease } = useGetDisease(bodyDiseaseIds);
+  const { data: animal } = useGetAnimal();
 
   useEffect(() => {
     if (isOpen) {
@@ -70,18 +82,25 @@ const CategoryContent = () => {
   }, [isOpen]);
 
   useEffect(() => {
+    if (animal?.animals) {
+      setCategoryData("breeds", animal.animals);
+    }
     if (symptoms?.bodies) {
       setCategoryData("symptoms", symptoms.bodies);
     }
     if (disease?.bodies) {
       setCategoryData("disease", disease.bodies);
     }
-  }, [symptoms, disease, setCategoryData]);
+  }, [animal, symptoms, disease, setCategoryData]);
 
   useEffect(() => {
     if (diseaseBodies?.bodies && symptomBodies?.bodies) {
-      const diseaseIdArr = diseaseBodies.bodies.map((item) => item.id as number);
-      const symptomIdArr = symptomBodies.bodies.map((item) => item.id as number);
+      const diseaseIdArr = diseaseBodies.bodies.map(
+        (item) => item.id as number,
+      );
+      const symptomIdArr = symptomBodies.bodies.map(
+        (item) => item.id as number,
+      );
       if (diseaseIdArr.length && symptomIdArr.length) {
         setBodyDiseaseIds(diseaseIdArr);
         setBodySymptomsIds(symptomIdArr);
@@ -90,28 +109,38 @@ const CategoryContent = () => {
   }, [diseaseBodies, symptomBodies]);
 
   const isFilterOn =
-    !!selectedChips.breedId.length || !!selectedChips.diseaseIds.length || !!selectedChips.symptomIds.length;
+    !!selectedChips.breedId.length ||
+    !!selectedChips.diseaseIds.length ||
+    !!selectedChips.symptomIds.length;
 
-  const fetchPostData = useCallback(() => {
-    if (!typeId) return;
+  const fetchPostData = useCallback(
+    (chipsOverride?: SelectedChips) => {
+      if (!typeId) return;
 
-    const filterPayload: postPostFiltersRequest = {
-      categoryId: Number(typeId),
-      sortBy: "RECENT",
-      animalIds: selectedChips.breedId.length > 0 ? selectedChips.breedId : undefined,
-      symptomIds: selectedChips.symptomIds.length > 0 ? selectedChips.symptomIds : undefined,
-      diseaseIds: selectedChips.diseaseIds.length > 0 ? selectedChips.diseaseIds : undefined,
-    };
+      const chipsToUse = chipsOverride || selectedChips;
 
-    fetchPosts(filterPayload, {
-      onSuccess: (data) => {
-        setPosts(data);
-      },
-      onError: (error) => {
-        console.error("필터링된 게시글 조회 실패:", error);
-      },
-    });
-  }, [fetchPosts, typeId, selectedChips]);
+      const filterPayload: postPostFiltersRequest = {
+        categoryId: Number(typeId),
+        sortBy: "RECENT",
+        animalIds:
+          chipsToUse.breedId.length > 0 ? chipsToUse.breedId : undefined,
+        symptomIds:
+          chipsToUse.symptomIds.length > 0 ? chipsToUse.symptomIds : undefined,
+        diseaseIds:
+          chipsToUse.diseaseIds.length > 0 ? chipsToUse.diseaseIds : undefined,
+      };
+
+      fetchPosts(filterPayload, {
+        onSuccess: (data) => {
+          setPosts(data);
+        },
+        onError: (error) => {
+          console.error("필터링된 게시글 조회 실패:", error);
+        },
+      });
+    },
+    [fetchPosts, typeId, selectedChips],
+  );
 
   const handleGoBack = () => {
     clearAllChips();
@@ -126,8 +155,8 @@ const CategoryContent = () => {
     clearAllChips();
   };
 
-  const onSubmitClick = () => {
-    fetchPostData();
+  const onSubmitClick = (selectedChipsFromProps?: SelectedChips) => {
+    fetchPostData(selectedChipsFromProps);
   };
 
   const { isAuthenticated } = useAuth();
@@ -156,7 +185,10 @@ const CategoryContent = () => {
           label={"아직 등록된 게시물이 없어요"}
           onBtnClick={() => router.push(`/community/write?category=${type}`)}
         />
-        <FilterBottomSheet handleDimmedClose={handleDimmedClose} onSubmitClick={onSubmitClick} />
+        <FilterBottomSheet
+          handleDimmedClose={handleDimmedClose}
+          onSubmitClick={onSubmitClick}
+        />
       </>
     );
   }
@@ -176,21 +208,25 @@ const CategoryContent = () => {
             onLeftClick={handleGoBack}
             onRightClick={handleGoSearch}
           />
-          {type !== "magazine" && (
-            <div className={styles.filterContainer}>
-              {isFilterOn ? (
-                <Icfilteron onClick={() => setOpen(true)} width={24} />
-              ) : (
-                <Icfilter onClick={() => setOpen(true)} width={24} />
-              )}
-            </div>
-          )}
+          <div className={styles.postsContainer}>
+            <If condition={type !== "magazine"}>
+              <SearchFilter
+                isActive={isFilterOn}
+                onFilterClick={(selectedChipsFromProps) =>
+                  onSubmitClick(selectedChipsFromProps)
+                }
+              />
+            </If>
+          </div>
           <NoData
             label={"아직 등록된 리뷰가 없어요"}
             onBtnClick={() => router.push(`/community/write?category=${type}`)}
           />
         </div>
-        <FilterBottomSheet handleDimmedClose={handleDimmedClose} onSubmitClick={onSubmitClick} />
+        <FilterBottomSheet
+          handleDimmedClose={handleDimmedClose}
+          onSubmitClick={onSubmitClick}
+        />
       </>
     );
   }
@@ -207,34 +243,33 @@ const CategoryContent = () => {
           onLeftClick={handleGoBack}
           onRightClick={handleGoSearch}
         />
-
-        {type !== "magazine" && (
-          <div className={styles.filterContainer}>
-            {isFilterOn ? (
-              <Icfilteron onClick={() => setOpen(true)} width={24} />
-            ) : (
-              <Icfilter onClick={() => setOpen(true)} width={24} />
-            )}
-          </div>
-        )}
-
         <div className={styles.postsContainer}>
-          {posts.map((post) => (
-            <Content
-              key={post.id}
-              breed={type === "magazine" ? "코코스" : post.breed}
-              petAge={type === "magazine" ? undefined : post.petAge}
-              postTitle={post.title}
-              postContent={post.content}
-              likeCnt={post.likeCount}
-              commentCnt={post.commentCount}
-              postImage={post.image}
-              onClick={() => router.push(`${PATH.COMMUNITY.ROOT}/${post.id}`)}
-              timeAgo={formatTime(post.updatedAt as string)}
-              category={post.category}
-              likeIconType="curious"
+          <If condition={type !== "magazine"}>
+            <SearchFilter
+              isActive={isFilterOn}
+              onFilterClick={(selectedChipsFromProps) =>
+                onSubmitClick(selectedChipsFromProps)
+              }
             />
-          ))}
+          </If>
+          <div className={styles.postsContent}>
+            {posts.map((post) => (
+              <Content
+                key={post.id}
+                breed={type === "magazine" ? "코코스" : post.breed}
+                petAge={type === "magazine" ? undefined : post.petAge}
+                postTitle={post.title}
+                postContent={post.content}
+                likeCnt={post.likeCount}
+                commentCnt={post.commentCount}
+                postImage={post.image}
+                onClick={() => router.push(`${PATH.COMMUNITY.ROOT}/${post.id}`)}
+                timeAgo={formatTime(post.updatedAt as string)}
+                category={post.category}
+                likeIconType="curious"
+              />
+            ))}
+          </div>
         </div>
 
         {type !== "magazine" && (
@@ -243,7 +278,10 @@ const CategoryContent = () => {
           </div>
         )}
       </div>
-      <FilterBottomSheet handleDimmedClose={handleDimmedClose} onSubmitClick={onSubmitClick} />
+      <FilterBottomSheet
+        handleDimmedClose={handleDimmedClose}
+        onSubmitClick={onSubmitClick}
+      />
       <LoginModal isOpen={isLoginModalOpen} setIsOpen={setIsLoginModalOpen} />
     </>
   );

--- a/src/app/community/write/Write.tsx
+++ b/src/app/community/write/Write.tsx
@@ -82,8 +82,8 @@ const Write = () => {
   const { data: disease } = useGetDisease(bodyDiseaseIds);
   const { data: writableCategories } = useGetWritableCategoryData();
   const dropDownItems = useMemo(
-    () => formatCategoriesToDropDownItems(writableCategories?.categories),
-    [writableCategories?.categories],
+    () => formatCategoriesToDropDownItems(writableCategories),
+    [writableCategories],
   );
 
   const [params, setParams] = useState<writeProps>({
@@ -134,9 +134,7 @@ const Write = () => {
 
   useEffect(() => {
     if (category && dropDownItems.length) {
-      const matchedItem = dropDownItems.find(
-        (item) => item.english === category,
-      );
+      const matchedItem = dropDownItems.find((item) => item.label === category);
       if (matchedItem) {
         setParams((prevParams) => ({
           ...prevParams,
@@ -370,7 +368,7 @@ const Write = () => {
           </WriteInputSection>
           {/* 태그 선택 영역 */}
           <WriteInputSection title={"태그 선택"}>
-            {TagLabel.map((tag, index) => (
+            {TagLabel.map((tag) => (
               <React.Fragment key={`tag-fragment-${tag.label}`}>
                 <Tag
                   key={`tag-${tag.label}`}

--- a/src/app/community/write/Write.tsx
+++ b/src/app/community/write/Write.tsx
@@ -43,7 +43,7 @@ import {
   getDropdownIdtoIcon,
   getDropdownIdtoValue,
 } from "@app/community/_utills/handleCategoryItem.tsx";
-import { formatCategoriesToDropDownItems } from "@app/community/_utills/formatWritableCategories.ts";
+import { formatCategoriesToDropDownItems } from "@app/community/_utills/formatWritableCategories.tsx";
 
 interface writeProps {
   categoryId: number | undefined;

--- a/src/app/community/write/Write.tsx
+++ b/src/app/community/write/Write.tsx
@@ -1,10 +1,22 @@
 import DropDown from "@app/community/_component/DropDown/DropDown.tsx";
 import { TextField } from "@common/component/TextField";
 import { IcAddphoto, IcDeleteBlack, IcRightArror } from "@asset/svg";
-import React, { ChangeEvent, useEffect, useRef, useState } from "react";
+import React, {
+  ChangeEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useDropDown } from "@app/community/_component/DropDown/useDropDown";
 import HeaderNav from "@common/component/HeaderNav/HeaderNav";
-import { bottomButton, fileInput, imageContainer, plusImage, writeWrap } from "@app/community/write/Write.css.ts";
+import {
+  bottomButton,
+  fileInput,
+  imageContainer,
+  plusImage,
+  writeWrap,
+} from "@app/community/write/Write.css.ts";
 import WriteInputSection from "@app/community/_component/WriteInputSection/WriteInputSection.tsx";
 
 import Tag from "@app/community/_component/Tag/Tag.tsx";
@@ -18,18 +30,20 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { PATH } from "@route/path.ts";
 import axios from "axios";
 import { FillterToName } from "@app/community/_utills/getFillterNamebyid.ts";
-import { useGetBodies, useGetDisease, useGetSymptoms } from "@api/domain/mypage/edit-pet/hook.ts";
-import { getDropdownIdtoIcon, getDropdownIdtoValue } from "@app/community/_utills/handleCategoryItem.tsx";
+import {
+  useGetBodies,
+  useGetDisease,
+  useGetSymptoms,
+} from "@api/domain/mypage/edit-pet/hook.ts";
 import { useArticlePost } from "@api/domain/community/post/hook.ts";
-import { DropDownItems } from "@app/community/_constant/writeConfig.tsx";
 import { CustomAxiosError } from "@type/global";
 import WorningToastWrap from "@common/component/WarnningToastWrap/WarningToastWrap";
-
-interface DropDownItem {
-  english: string;
-  label: string;
-  value: number;
-}
+import { useGetWritableCategoryData } from "@api/domain/review/write/hook.ts";
+import {
+  getDropdownIdtoIcon,
+  getDropdownIdtoValue,
+} from "@app/community/_utills/handleCategoryItem.tsx";
+import { formatCategoriesToDropDownItems } from "@app/community/_utills/formatWritableCategories.ts";
 
 interface writeProps {
   categoryId: number | undefined;
@@ -50,7 +64,14 @@ const Write = () => {
   const [imageNames, setImageNames] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { isDropDownOpen, toggleDropDown, closeDropDown } = useDropDown();
-  const { selectedChips, isOpen, setOpen, clearAllChips, setCategoryData, setCategory } = useFilterStore();
+  const {
+    selectedChips,
+    isOpen,
+    setOpen,
+    clearAllChips,
+    setCategoryData,
+    setCategory,
+  } = useFilterStore();
   const [bodyDiseaseIds, setBodyDiseaseIds] = useState<number[]>([]);
   const [bodySymptomsIds, setBodySymptomsIds] = useState<number[]>([]);
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -59,8 +80,14 @@ const Write = () => {
   const { mutate } = useArticlePost();
   const { data: symptoms } = useGetSymptoms(bodySymptomsIds);
   const { data: disease } = useGetDisease(bodyDiseaseIds);
+  const { data: writableCategories } = useGetWritableCategoryData();
+  const dropDownItems = useMemo(
+    () => formatCategoriesToDropDownItems(writableCategories?.categories),
+    [writableCategories?.categories],
+  );
+
   const [params, setParams] = useState<writeProps>({
-    categoryId: 1,
+    categoryId: undefined,
     title: "",
     content: "",
     images: [],
@@ -106,16 +133,18 @@ const Write = () => {
   }, [isOpen]);
 
   useEffect(() => {
-    if (category) {
-      const matchedItem = DropDownItems.find((item: DropDownItem) => item.english === category);
+    if (category && dropDownItems.length) {
+      const matchedItem = dropDownItems.find(
+        (item) => item.english === category,
+      );
       if (matchedItem) {
         setParams((prevParams) => ({
           ...prevParams,
-          categoryId: matchedItem ? matchedItem.value : undefined,
+          categoryId: matchedItem.value,
         }));
       }
     }
-  }, [category]);
+  }, [category, dropDownItems]);
 
   useEffect(() => {
     if (symptoms?.bodies) {
@@ -128,8 +157,12 @@ const Write = () => {
 
   useEffect(() => {
     if (diseaseBodies?.bodies && symptomBodies?.bodies) {
-      const diseaseIdArr = diseaseBodies.bodies.map((item) => item.id as number);
-      const symptomIdArr = symptomBodies.bodies.map((item) => item.id as number);
+      const diseaseIdArr = diseaseBodies.bodies.map(
+        (item) => item.id as number,
+      );
+      const symptomIdArr = symptomBodies.bodies.map(
+        (item) => item.id as number,
+      );
       if (diseaseIdArr.length && symptomIdArr.length) {
         setBodyDiseaseIds(diseaseIdArr);
         setBodySymptomsIds(symptomIdArr);
@@ -138,7 +171,9 @@ const Write = () => {
   }, [diseaseBodies, symptomBodies]);
 
   const onTextFieldChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const selectedValue = DropDownItems.find((item) => item.label === e.target.value);
+    const selectedValue = dropDownItems.find(
+      (item) => item.label === e.target.value,
+    );
     if (!selectedValue) return;
     onChangeValue("categoryId", selectedValue.value);
     if (!isDropDownOpen) closeDropDown();
@@ -148,7 +183,10 @@ const Write = () => {
     toggleDropDown();
   };
 
-  const onChangeValue = (target: string, value: string | number | React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeValue = (
+    target: string,
+    value: string | number | React.ChangeEvent<HTMLInputElement>,
+  ) => {
     setParams({
       ...params,
       [target]: value,
@@ -255,28 +293,38 @@ const Write = () => {
   };
 
   const isAllParamsFilled =
-    params.categoryId && params.title && params.content && params.selectedChips.breedId.length > 0;
+    params.categoryId &&
+    params.title &&
+    params.content &&
+    params.selectedChips.breedId.length > 0;
 
   return (
     <>
-      <WorningToastWrap errorMessage={errorMessage} setErrorMessage={setErrorMessage} />
+      <WorningToastWrap
+        errorMessage={errorMessage}
+        setErrorMessage={setErrorMessage}
+      />
       <div>
-        <HeaderNav leftIcon={<IcDeleteBlack width={24} />} onLeftClick={onBackClick} centerContent={"글쓰기"} />
+        <HeaderNav
+          leftIcon={<IcDeleteBlack width={24} />}
+          onLeftClick={onBackClick}
+          centerContent={"글쓰기"}
+        />
         <div className={writeWrap}>
           {/* 제목 영역 */}
           <WriteInputSection title={"게시판 선택"}>
             <TextField
-              leftIcon={getDropdownIdtoIcon(params.categoryId)}
+              leftIcon={getDropdownIdtoIcon(params.categoryId, dropDownItems)}
               icon={<IcRightArror width={20} />}
               placeholder={"게시물 선택하기"}
               onChange={onTextFieldChange}
               onClick={onTextFieldClick}
               isDelete={false}
-              value={getDropdownIdtoValue(params.categoryId)}
+              value={getDropdownIdtoValue(params.categoryId, dropDownItems)}
             />
             <DropDown
               isOpen={isDropDownOpen}
-              items={DropDownItems}
+              items={dropDownItems}
               onClickItem={onChangeValue}
               toggleDropDown={toggleDropDown}
             />
@@ -298,9 +346,18 @@ const Write = () => {
               onChange={(e) => onChangeValue("content", e.target.value)}
             />
             <Spacing marginBottom={"1.2"} />
-            <input type="file" onChange={handleAddImage} accept="image/*" ref={fileInputRef} className={fileInput} />
+            <input
+              type="file"
+              onChange={handleAddImage}
+              accept="image/*"
+              ref={fileInputRef}
+              className={fileInput}
+            />
             <div className={imageContainer}>
-              <IcAddphoto className={plusImage} onClick={handleFileUploadClick} />
+              <IcAddphoto
+                className={plusImage}
+                onClick={handleFileUploadClick}
+              />
               {params.images.map((imageSrc, index) => (
                 <ImageCover
                   key={`image-${index}`}
@@ -326,7 +383,10 @@ const Write = () => {
                     setCategory(tag.category || "breeds");
                   }}
                 />
-                <Spacing key={`spacing-write-${tag.label}`} marginBottom={"0.8"} />
+                <Spacing
+                  key={`spacing-write-${tag.label}`}
+                  marginBottom={"0.8"}
+                />
               </React.Fragment>
             ))}
           </WriteInputSection>

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -2,7 +2,7 @@
 
 import { TextField } from "@common/component/TextField";
 import { IcAddphoto, IcDeleteBlack, IcRightArror } from "@asset/svg";
-import React, { ChangeEvent, Suspense, useEffect, useRef, useState } from "react";
+import React, { ChangeEvent, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useDropDown } from "../_component/DropDown/useDropDown";
 import HeaderNav from "@common/component/HeaderNav/HeaderNav";
 
@@ -18,11 +18,12 @@ import { useArticlePost } from "@api/domain/community/post/hook.ts";
 import { CustomAxiosError } from "@type/global";
 import WorningToastWrap from "@common/component/WarnningToastWrap/WarningToastWrap.tsx";
 import { FillterToName } from "../_utills/getFillterNamebyid.ts";
-import { DropDownItems } from "../_constant/writeConfig.tsx";
 import { bottomButton, fileInput, imageContainer, plusImage, writeWrap } from "./Write.css.ts";
 import WriteInputSection from "../_component/WriteInputSection/WriteInputSection.tsx";
-import { getDropdownIdtoIcon, getDropdownIdtoValue } from "../_utills/handleCategoryItem.tsx";
+import { useGetWritableCategoryData } from "@api/domain/review/write/hook.ts";
 import DropDown from "../_component/DropDown/DropDown.tsx";
+import { getDropdownIdtoIcon, getDropdownIdtoValue } from "../_utills/handleCategoryItem.tsx";
+import { formatCategoriesToDropDownItems } from "../_utills/formatWritableCategories.tsx";
 import TextArea from "../_component/TextArea/TextArea.tsx";
 import ImageCover from "../../../shared/component/ImageCover/ImageCover.tsx";
 import Tag from "../_component/Tag/Tag.tsx";
@@ -64,8 +65,13 @@ const WriteContent = () => {
   const { mutate } = useArticlePost();
   const { data: symptoms } = useGetSymptoms(bodySymptomsIds);
   const { data: disease } = useGetDisease(bodyDiseaseIds);
+  const { data: writableCategories } = useGetWritableCategoryData();
+  const dropDownItems = useMemo(
+    () => formatCategoriesToDropDownItems(writableCategories?.categories),
+    [writableCategories?.categories],
+  );
   const [params, setParams] = useState<writeProps>({
-    categoryId: 1,
+    categoryId: undefined,
     title: "",
     content: "",
     images: [],
@@ -111,16 +117,16 @@ const WriteContent = () => {
   }, [isOpen]);
 
   useEffect(() => {
-    if (category) {
-      const matchedItem = DropDownItems.find((item) => item.english === category);
+    if (category && dropDownItems.length) {
+      const matchedItem = dropDownItems.find((item) => item.english === category);
       if (matchedItem) {
         setParams((prevParams) => ({
           ...prevParams,
-          categoryId: matchedItem ? matchedItem.value : undefined,
+          categoryId: matchedItem.value,
         }));
       }
     }
-  }, []);
+  }, [category, dropDownItems]);
 
   useEffect(() => {
     if (symptoms?.bodies) {
@@ -143,7 +149,7 @@ const WriteContent = () => {
   }, [diseaseBodies, symptomBodies]);
 
   const onTextFieldChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const selectedValue = DropDownItems.find((item) => item.label === e.target.value);
+    const selectedValue = dropDownItems.find((item) => item.label === e.target.value);
     if (!selectedValue) return;
     onChangeValue("categoryId", selectedValue.value);
     if (!isDropDownOpen) closeDropDown();
@@ -271,17 +277,17 @@ const WriteContent = () => {
           {/* 제목 영역 */}
           <WriteInputSection title={"게시판 선택"}>
             <TextField
-              leftIcon={getDropdownIdtoIcon(params.categoryId)}
+              leftIcon={getDropdownIdtoIcon(params.categoryId, dropDownItems)}
               icon={<IcRightArror width={20} />}
               placeholder={"게시물 선택하기"}
               onChange={onTextFieldChange}
               onClick={onTextFieldClick}
               isDelete={false}
-              value={getDropdownIdtoValue(params.categoryId)}
+              value={getDropdownIdtoValue(params.categoryId, dropDownItems)}
             />
             <DropDown
               isOpen={isDropDownOpen}
-              items={DropDownItems}
+              items={dropDownItems}
               onClickItem={onChangeValue}
               toggleDropDown={toggleDropDown}
             />

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -67,8 +67,8 @@ const WriteContent = () => {
   const { data: disease } = useGetDisease(bodyDiseaseIds);
   const { data: writableCategories } = useGetWritableCategoryData();
   const dropDownItems = useMemo(
-    () => formatCategoriesToDropDownItems(writableCategories?.categories),
-    [writableCategories?.categories],
+    () => formatCategoriesToDropDownItems(writableCategories),
+    [writableCategories],
   );
   const [params, setParams] = useState<writeProps>({
     categoryId: undefined,


### PR DESCRIPTION
## 🔥 Related Issues

- close #523 

## ✅ 작업 리스트

- [x] writable category api 연동 
- [x] 작성 가능한 카테고리만 노출하도록 수정
- [x] 변경된 필터 UI 적용

## 📸 스크린샷 / GIF / Link

### [ 변경된 필터 UI 적용 ]
-> 기존 변경된 필터 UI 가 검색 완료 페이지에 구현되었는데, 그 부분을 똑같이 커뮤니티 카테고리 별 화면에도 적용되도록 했어요. 

<img width="436" height="485" alt="스크린샷 2026-06-11 23 54 28" src="https://github.com/user-attachments/assets/c07f4f2a-62c3-4297-bfef-48bacdfd6c3d" />

### [ writable category 만 화면에 뜨도록 수정 (백엔드 의존) ]
-> 기존에는 프론트에서 카테고리 데이터를 들고 있었는데, 이번 작업으로 api 를 호출해서 드롭다운에 노출하도록 변경했어요. 그래서 admin 권한인 사람한테만 " 코코스매거진" 카테고리가 드롭다운에 노출됩니다. admin 이 아니면, 드롭다운에 3가지 종류만 선택 가능하도록 노출해요. 

<img width="400" height="356" alt="스크린샷 2026-06-11 23 54 47" src="https://github.com/user-attachments/assets/9e1f21f9-1581-4fdd-9504-473adfb1e0f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 게시물 작성 시 서버에서 작성 가능한 카테고리를 동적으로 불러오는 기능 추가
  * 작성 가능한 카테고리 조회 훅 및 카테고리→드롭다운 변환 유틸 추가

* **개선사항**
  * 작성 페이지 및 카테고리 드롭다운이 동적 데이터 기반으로 동작하도록 변경
  * 카테고리 필터/목록 연동 로직 개선 및 필터 UI 위치·동작 조정
  * 카테고리 선택 아이콘·값 조회 로직과 관련 컴포넌트 타입/스타일 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->