### PR TITLE
[Refactor] 헤더, 위치qa

### DIFF
--- a/src/api/domain/review/location/hook.ts
+++ b/src/api/domain/review/location/hook.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
-import { getLocation, getMemberLocation } from "./index";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getLocation, getMemberLocation, updateMemberLocation } from "./index";
+import { UpdateMemberLocationRequest } from "./types";
 
 export const QUERY_KEY = {
   LOCATION: "location",
@@ -17,5 +18,12 @@ export const useGetMemberLocation = () => {
   return useQuery({
     queryKey: [QUERY_KEY.MEMBER_LOCATION],
     queryFn: () => getMemberLocation(),
+  });
+};
+
+export const useUpdateMemberLocation = () => {
+  return useMutation({
+    mutationFn: (locationData: UpdateMemberLocationRequest) =>
+      updateMemberLocation(locationData),
   });
 };

--- a/src/app/community/category/Category.css.ts
+++ b/src/app/community/category/Category.css.ts
@@ -15,6 +15,7 @@ export const categoryContainer = style({
 });
 
 export const postsContainer = style({
+  marginTop: "6.4rem",
   padding: "1.6rem 2rem 2rem 2rem",
   display: "flex",
   flexDirection: "column",

--- a/src/app/community/category/page.tsx
+++ b/src/app/community/category/page.tsx
@@ -24,7 +24,6 @@ import dynamic from "next/dynamic";
 import NoData from "@shared/component/NoData/NoData.tsx";
 import { useAuth } from "@providers/AuthProvider";
 import { useIsPetRegistered } from "@common/hook/useIsPetRegistered";
-import { Modal } from "@common/component/Modal/Modal";
 import LoginModal from "@common/component/LoginModal/LoginModal.tsx";
 import { SearchFilter } from "../_component/SearchFilter/SearchFilter";
 import { If } from "@shared/component/If/if";
@@ -240,14 +239,16 @@ const CategoryContent = () => {
   return (
     <>
       <div className={styles.categoryContainer}>
-        <HeaderNav
-          leftIcon={<IcLeftarrow />}
-          centerContent={categoryName}
-          rightBtn={<IcSearch />}
-          onLeftClick={handleGoBack}
-          onRightClick={handleGoSearch}
-        />
-        <div className={styles.postsContainer}>
+        <div className={styles.headerContainer}>
+          <HeaderNav
+            leftIcon={<IcLeftarrow />}
+            centerContent={categoryName}
+            rightBtn={<IcSearch />}
+            onLeftClick={handleGoBack}
+            onRightClick={handleGoSearch}
+          />
+        </div>
+        <div className={styles.postsContainer} style={{ marginTop: "6.4rem" }}>
           <If condition={type !== "magazine"}>
             <SearchFilter
               isActive={isFilterOn}

--- a/src/app/community/category/page.tsx
+++ b/src/app/community/category/page.tsx
@@ -248,7 +248,7 @@ const CategoryContent = () => {
             onRightClick={handleGoSearch}
           />
         </div>
-        <div className={styles.postsContainer} style={{ marginTop: "6.4rem" }}>
+        <div className={styles.postsContainer}>
           <If condition={type !== "magazine"}>
             <SearchFilter
               isActive={isFilterOn}

--- a/src/app/community/detail/_section/ReviewDetailContent.tsx
+++ b/src/app/community/detail/_section/ReviewDetailContent.tsx
@@ -1,9 +1,10 @@
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import * as styles from "@app/community/detail/SymptomDetail.css.ts";
 import { IcRightArrow } from "@asset/svg";
 import { LoadingFallback } from "@app/community/detail/_section/index.tsx";
 import { usePostHospitalReviews } from "@api/domain/community/detail/hook.ts";
+import { useUpdateMemberLocation } from "@api/domain/review/location/hook.ts";
 import NoData from "@shared/component/NoData/NoData.tsx";
 import HospitalReview from "@shared/component/HospitalReview/HospitalReview.tsx";
 import { postHospitalReviewsResponseData } from "@api/domain/community/detail";
@@ -69,6 +70,7 @@ const ReviewDetailContent = () => {
 
   // API
   const { mutate: postHospitalReviews, isPending } = usePostHospitalReviews();
+  const { mutate: updateLocation } = useUpdateMemberLocation();
 
   const handleProfileClick = (nickname: string | undefined) => {
     router.push(`/profile?nickname=${nickname}`);
@@ -110,8 +112,14 @@ const ReviewDetailContent = () => {
     postReviews(location, summaryOptionId);
   };
 
+  useEffect(() => {
+    postReviews(location);
+  }, []);
+
   const handleLocationSelect = (newLocation: LocationFilterType) => {
     setLocation(newLocation);
+    localStorage.setItem("selectedLocation", JSON.stringify(newLocation));
+    updateLocation({ locationId: newLocation.id, locationType: newLocation.type });
     postReviews(newLocation, filterId ? Number(filterId) : undefined);
   };
 


### PR DESCRIPTION
- 게시글 목록이 있을 때 HeaderNav를 headerContainer로 감싸 position fixed 적용
- postsContainer에 marginTop 추가하여 고정 헤더 영역 확보


## 🔥 Related Issues

- close #529 

## ✅ 작업 리스트

- [ ] 커뮤니티-게시판의 헤더를 고정했습니다

## 🔧 작업 내용

## 📣 리뷰어에게

## 📸 스크린샷 / GIF / Link
<헤더고정>

https://github.com/user-attachments/assets/577b7a7f-5e70-48a7-85af-4ba1ef3c4980


<위치>

https://github.com/user-attachments/assets/6abea2f5-c679-4fc9-a9ba-fd29987d9a5c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 카테고리 게시글 목록 상단 여백이 추가되어 화면 배치가 더 자연스러워졌습니다.
  * 게시글 작성 및 로그인 흐름에서 모달 표시가 더 일관되게 동작하도록 정리했습니다.

* **Style**
  * 카테고리 페이지의 헤더 관련 화면 구성을 정돈해 렌더링 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->