### PR TITLE
[Feat] release tagging을 위한 GitHub Actions workflow 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and create tag
+        id: release
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            MAJOR=0
+            MINOR=1
+            PATCH=0
+          else
+            VERSION=${LATEST_TAG#v}
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            MAJOR=${MAJOR:-0}
+            MINOR=${MINOR:-0}
+            PATCH=${PATCH:-0}
+
+            if echo "$PR_LABELS" | grep -qw 'release:major'; then
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+            elif echo "$PR_LABELS" | grep -qw 'release:minor'; then
+              MINOR=$((MINOR + 1))
+              PATCH=0
+            else
+              PATCH=$((PATCH + 1))
+            fi
+          fi
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          TAG="v${NEW_VERSION}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
+
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '${NEW_VERSION}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          git add package.json
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "$TAG" -m "Release ${TAG}"
+
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Push release commit and tag
+        run: git push origin main --follow-tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.release.outputs.tag }}" \
+            --title "${{ steps.release.outputs.tag }}" \
+            --generate-notes \
+            --target main


### PR DESCRIPTION
## 🔥 Related Issues

- close #536

## ✅ 작업 리스트

- [x] release tagging을 위한 GitHub Actions workflow 추가

## 🔧 작업 내용

### 동작 방식
```
develop → main PR 머지
       ↓
최신 v* 태그 확인
       ↓
버전 bump + package.json 업데이트
       ↓
main에 commit + vX.Y.Z 태그 push
       ↓
GitHub Release 생성 (자동 릴리스 노트)
```


### 버전 규칙

상황 | 버전
-- | --
태그 없음 (첫 릴리스) | v0.1.0
기본 (라벨 없음) | patch +1 → v0.1.0 → v0.1.1
PR에 release:minor 라벨 | minor +1 → v0.1.3 → v0.2.0
PR에 release:major 라벨 | major +1 → v0.2.3 → v1.0.0

### 사용 예시

1. develop → main PR 생성
2. (선택) minor/major 올리려면 PR에 release:minor 또는 release:major 라벨 붙이기
3. PR 머지
4. Actions에서 Release Tag 워크플로 실행 확인
5. v0.1.1 같은 태그 + GitHub Release 자동 생성



## 📣 리뷰어에게

- develop → main PR 머지일 때만 실행됩니다. main에 다른 브랜치를 직접 머지하면 태그가 안 붙습니다.
- package.json의 version도 함께 업데이트됩니다.
- GITHUB_TOKEN 권한(contents: write)으로 태그 push와 Release 생성이 됩니다. 별도 secret은 필요 없습니다.
